### PR TITLE
Fix build errors on MacOS (and maybe linux?)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,10 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tungstenite = { version = "0.28.0", features = ["rustls-tls-native-roots"] }
 url = "2.5.8"
-windows = { version = "0.62.2", features = ["Win32_Foundation", "Win32_System_Com", "Win32_System_Ole", "Win32_System_Threading", "Win32_System_Variant", "Win32_UI_Accessibility", "Win32_UI_Input", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging"] }
 wxdragon = { git = "https://github.com/aryanchoudharypro/wxDragon", branch = "main" }
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.62.2", features = ["Win32_Foundation", "Win32_System_Com", "Win32_System_Ole", "Win32_System_Threading", "Win32_System_Variant", "Win32_UI_Accessibility", "Win32_UI_Input", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging"] }
 
 [build-dependencies]
 embed-manifest = "1.5.0"

--- a/src/live_region.rs
+++ b/src/live_region.rs
@@ -91,7 +91,7 @@ mod windows_impl {
 
 #[cfg(not(target_os = "windows"))]
 mod windows_impl {
-	use wxdragon::prelude::wxWidget;
+	use wxdragon::prelude::WxWidget;
 
 	pub fn set_live_region(_window: &impl WxWidget) -> bool {
 		false

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::all, clippy::pedantic, clippy::nursery)]
 #![allow(clippy::too_many_arguments, clippy::too_many_lines)] // temp
-#![deny(warnings)]
+#![cfg_attr(windows, deny(warnings))]
 #![windows_subsystem = "windows"]
 
 mod accounts;


### PR DESCRIPTION
Fixed issues with doing builds on MacOS. Updated to deny warnings on windows only to avoid having a lot of unused import errors.

Tested on MacOS, I think it will probably work on Linux.