### PR TITLE
Fix follower/following lists for remote accounts

### DIFF
--- a/src/mastodon.rs
+++ b/src/mastodon.rs
@@ -1568,6 +1568,59 @@ impl MastodonClient {
 		Ok(accounts)
 	}
 
+	pub fn get_remote_followers(&self, acct: &str) -> Result<Vec<Account>> {
+		let (base_url, remote_id) = self.resolve_remote_account(acct)?;
+		let url = base_url.join(&format!("api/v1/accounts/{remote_id}/followers"))?;
+		let accounts: Vec<Account> = self
+			.http
+			.get(url)
+			.send()
+			.context("Failed to fetch remote followers")?
+			.error_for_status()
+			.context("Remote instance rejected followers request")?
+			.json()
+			.context("Invalid remote followers response")?;
+		Ok(accounts)
+	}
+
+	pub fn get_remote_following(&self, acct: &str) -> Result<Vec<Account>> {
+		let (base_url, remote_id) = self.resolve_remote_account(acct)?;
+		let url = base_url.join(&format!("api/v1/accounts/{remote_id}/following"))?;
+		let accounts: Vec<Account> = self
+			.http
+			.get(url)
+			.send()
+			.context("Failed to fetch remote following")?
+			.error_for_status()
+			.context("Remote instance rejected following request")?
+			.json()
+			.context("Invalid remote following response")?;
+		Ok(accounts)
+	}
+
+	fn resolve_remote_account(&self, acct: &str) -> Result<(Url, String)> {
+		let domain = acct
+			.split('@')
+			.nth(1)
+			.ok_or_else(|| anyhow::anyhow!("Invalid remote acct: {acct}"))?;
+		if domain.is_empty() {
+			return Err(anyhow::anyhow!("Invalid remote acct: {acct}"));
+		}
+		let base_url = Url::parse(&format!("https://{domain}/"))?;
+		let mut lookup_url = base_url.join("api/v1/accounts/lookup")?;
+		lookup_url.query_pairs_mut().append_pair("acct", acct);
+		let account: Account = self
+			.http
+			.get(lookup_url)
+			.send()
+			.context("Failed to lookup account on remote instance")?
+			.error_for_status()
+			.context("Could not find this account on their home instance")?
+			.json()
+			.context("Invalid account response from remote instance")?;
+		Ok((base_url, account.id))
+	}
+
 	pub fn search(
 		&self,
 		access_token: &str,

--- a/src/network.rs
+++ b/src/network.rs
@@ -191,9 +191,11 @@ pub enum NetworkCommand {
 	},
 	FetchFollowers {
 		account_id: String,
+		acct: String,
 	},
 	FetchFollowing {
 		account_id: String,
+		acct: String,
 	},
 	VotePoll {
 		poll_id: String,
@@ -938,12 +940,20 @@ fn network_loop(
 				let result = client.get_favourited_by(access_token, &status_id);
 				send_response(responses, ui_waker, NetworkResponse::FavoritedByLoaded { result });
 			}
-			Ok(NetworkCommand::FetchFollowers { account_id }) => {
-				let result = client.get_followers(access_token, &account_id);
+			Ok(NetworkCommand::FetchFollowers { account_id, acct }) => {
+				let result = if acct.contains('@') {
+					client.get_remote_followers(&acct)
+				} else {
+					client.get_followers(access_token, &account_id)
+				};
 				send_response(responses, ui_waker, NetworkResponse::FollowersLoaded { result });
 			}
-			Ok(NetworkCommand::FetchFollowing { account_id }) => {
-				let result = client.get_following(access_token, &account_id);
+			Ok(NetworkCommand::FetchFollowing { account_id, acct }) => {
+				let result = if acct.contains('@') {
+					client.get_remote_following(&acct)
+				} else {
+					client.get_following(access_token, &account_id)
+				};
 				send_response(responses, ui_waker, NetworkResponse::FollowingLoaded { result });
 			}
 			Ok(NetworkCommand::FollowAccount { account_id, target_name, reblogs, action }) => {

--- a/src/ui/dialogs/profile.rs
+++ b/src/ui/dialogs/profile.rs
@@ -170,11 +170,13 @@ impl ProfileDialog {
 				return;
 			}
 			if id == ID_ACTION_VIEW_FOLLOWERS {
-				let _ = net_tx_handler.send(NetworkCommand::FetchFollowers { account_id });
+				let acct = account.acct.clone();
+				let _ = net_tx_handler.send(NetworkCommand::FetchFollowers { account_id, acct });
 				return;
 			}
 			if id == ID_ACTION_VIEW_FOLLOWING {
-				let _ = net_tx_handler.send(NetworkCommand::FetchFollowing { account_id });
+				let acct = account.acct.clone();
+				let _ = net_tx_handler.send(NetworkCommand::FetchFollowing { account_id, acct });
 				return;
 			}
 


### PR DESCRIPTION
Mastodon only federates a partial follower/following list to other instances, so viewing these lists for a remote account from your home instance often returns an empty or very incomplete result. Typically, you will only see accounts that belong to your home instance, and/or those that the home instance knows about.

This is a known upstream limitation (see mastodon/mastodon#8301).

This change fixes the issue by detecting when the viewed account is on a different instance and fetching the list from their home instance directly instead.

## Technical details

The `acct` field on a Mastodon account is `username` for local accounts and `username@domain` for remote ones. When the followers or following list is requested, the code now checks for the `@`. If present, it hits `/api/v1/accounts/lookup` on the remote instance to resolve the account's local ID there, then fetches the follower/following list from that same instance. No authentication is needed since both endpoints are public.

The logic for local accounts remains unchanged.

One known edge case: if your home instance has stored a remote account's `acct` without the `@domain` suffix (which can happen due to federation normalization), the code will not detect it as remote and will fall back to the local incomplete list rather than fetching from the home instance.

## Code changes

- `src/mastodon.rs`: added `get_remote_followers`, `get_remote_following`, and a private `resolve_remote_account` helper
- `src/network.rs`: added `acct` field to `FetchFollowers` and `FetchFollowing` commands, plus routing logic
- `src/ui/dialogs/profile.rs`: passes `acct` alongside `account_id` when sending those commands

## Security considerations

Since we're looking up the user's following/followers lists using a separate instance, the requesting user's IP is revealed to that instance. I believe the ramifications of this are minimal: IP tracking is unfortunately commonplace across the internet, and someone wishing to view a full list of followers on the web has to hit another instance anyway. My assumption is that users who care will be using a VPN.

That said, this may need to be documented somewhere or optionally added as a toggle depending on what the user base is likely to want.