### PR TITLE
Increase followers/following page size to API maximum

### DIFF
--- a/src/mastodon.rs
+++ b/src/mastodon.rs
@@ -1541,7 +1541,8 @@ impl MastodonClient {
 	}
 
 	pub fn get_followers(&self, access_token: &str, account_id: &str) -> Result<Vec<Account>> {
-		let url = self.base_url.join(&format!("api/v1/accounts/{account_id}/followers"))?;
+		let mut url = self.base_url.join(&format!("api/v1/accounts/{account_id}/followers"))?;
+		url.query_pairs_mut().append_pair("limit", "80");
 		let response = self
 			.http
 			.get(url)
@@ -1555,7 +1556,8 @@ impl MastodonClient {
 	}
 
 	pub fn get_following(&self, access_token: &str, account_id: &str) -> Result<Vec<Account>> {
-		let url = self.base_url.join(&format!("api/v1/accounts/{account_id}/following"))?;
+		let mut url = self.base_url.join(&format!("api/v1/accounts/{account_id}/following"))?;
+		url.query_pairs_mut().append_pair("limit", "80");
 		let response = self
 			.http
 			.get(url)


### PR DESCRIPTION
This pull request simply grabs 80 accounts per page (instead of the default of 40) when a user views the following/followers lists, which is the maximum allowed by the Mastodon API.

Eventually, it would be great to see full pagination support in the following/followers dialogs mirroring the "load more" behavior that currently exists for timelines.