### PR TITLE
docs: contributor setup and pre-commit hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,23 @@ For a comprehensive user guide, including a full list of features and hotkeys, p
 
 ## Building
 
-To build, you'll need cargo, as well as CMake and Ninja for building wxDragon. In addition, you also need LLVM, from LLVM.org. 
+To build, you'll need cargo, as well as CMake and Ninja for building wxDragon. In addition, you also need LLVM, from LLVM.org.
+
+### Toolchains
+
+- Stable Rust `1.88.0` is used for builds, tests, and clippy.
+- Nightly Rust is only required for formatting with `cargo +nightly fmt`.
+
+### Native Dependencies
+
+Fedra expects a local `wxWidgets` checkout and the `WXWIDGETS_DIR` environment variable to point to it.
+
+On PowerShell:
+
+```powershell
+git clone --recurse-submodules https://github.com/wxWidgets/wxWidgets.git
+$env:WXWIDGETS_DIR = "$PWD\\wxWidgets"
+```
 
 ```batch
 cargo build --release
@@ -22,6 +38,29 @@ The following tools aren't required to build a functioning Fedra on a basic leve
 
 * `pandoc` on your `PATH` to generate the HTML readme.
 * InnoSetup installed to create the installer.
+
+## Before Committing
+
+Run the formatter before you commit changes:
+
+```batch
+cargo +nightly fmt
+```
+
+Set up the repository pre-commit hooks from the repo root:
+
+```batch
+cargo install prek
+prek install
+```
+
+Run the same checks that CI expects:
+
+```batch
+cargo +nightly fmt --check
+cargo test
+cargo clippy --release
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To build, you'll need cargo, as well as CMake and Ninja for building wxDragon. I
 
 ### Native Dependencies
 
-Fedra expects a local `wxWidgets` checkout and the `WXWIDGETS_DIR` environment variable to point to it.
+Due to accessibility issues observed in current versions of WX, Fedra expects a local `wxWidgets` checkout and the `WXWIDGETS_DIR` environment variable to point to it.
 
 On PowerShell:
 

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,19 @@
+[[repos]]
+repo = "builtin"
+hooks = [
+	{ id = "trailing-whitespace" },
+	{ id = "end-of-file-fixer" }
+]
+
+[[repos]]
+repo = "local"
+hooks = [
+	{
+		id = "cargo-fmt",
+		name = "cargo fmt (nightly)",
+		entry = "cargo +nightly fmt --all --",
+		language = "system",
+		types = ["rust"],
+		pass_filenames = false
+	}
+]

--- a/src/mastodon.rs
+++ b/src/mastodon.rs
@@ -1559,11 +1559,8 @@ impl MastodonClient {
 			req = req.bearer_auth(token);
 		}
 		let response = req.send()?.error_for_status()?;
-		let next_max_id = response
-			.headers()
-			.get("link")
-			.and_then(|h| h.to_str().ok())
-			.and_then(Self::parse_link_header);
+		let next_max_id =
+			response.headers().get("link").and_then(|h| h.to_str().ok()).and_then(Self::parse_link_header);
 		let accounts: Vec<Account> = response.json()?;
 		Ok((accounts, next_max_id))
 	}
@@ -1616,10 +1613,7 @@ impl MastodonClient {
 	}
 
 	fn resolve_remote_account(&self, acct: &str) -> Result<(Url, String)> {
-		let domain = acct
-			.split('@')
-			.nth(1)
-			.ok_or_else(|| anyhow::anyhow!("Invalid remote acct: {acct}"))?;
+		let domain = acct.split('@').nth(1).ok_or_else(|| anyhow::anyhow!("Invalid remote acct: {acct}"))?;
 		if domain.is_empty() {
 			return Err(anyhow::anyhow!("Invalid remote acct: {acct}"));
 		}

--- a/src/network.rs
+++ b/src/network.rs
@@ -974,7 +974,11 @@ fn network_loop(
 				} else {
 					client.get_followers_page(access_token, &account_id, None)
 				};
-				send_response(responses, ui_waker, NetworkResponse::FollowersLoaded { result, total_count, account_id });
+				send_response(
+					responses,
+					ui_waker,
+					NetworkResponse::FollowersLoaded { result, total_count, account_id },
+				);
 			}
 			Ok(NetworkCommand::FetchFollowing { account_id, acct, total_count }) => {
 				let result = if acct.contains('@') {
@@ -982,7 +986,11 @@ fn network_loop(
 				} else {
 					client.get_following_page(access_token, &account_id, None)
 				};
-				send_response(responses, ui_waker, NetworkResponse::FollowingLoaded { result, total_count, account_id });
+				send_response(
+					responses,
+					ui_waker,
+					NetworkResponse::FollowingLoaded { result, total_count, account_id },
+				);
 			}
 			Ok(NetworkCommand::FetchNextFollowersPage { account_id, max_id }) => {
 				let result = client.get_followers_page(access_token, &account_id, Some(&max_id));


### PR DESCRIPTION
- Document the stable/nightly Rust toolchain split and the need to set the `WXWIDGETS_DIR` environment variable (thanks to accessibility breakage in WX)
- Add a "Before Committing" section covering `cargo +nightly fmt`, hook installation via `prek`, and commands to check ahead of time so that CI does not fail
- Add `prek.toml` with trailing-whitespace, end-of-file, and `cargo fmt` hooks, copied verbatim from the Paperback repo