### PR TITLE
Fix timelines never refreshing automatically (#77)

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -166,7 +166,7 @@ pub fn refresh_timeline(state: &AppState, live_region: &crate::ui::timeline_list
 pub fn poll_non_streaming_timelines(state: &AppState) {
 	let Some(handle) = &state.network_handle else { return };
 	for timeline in state.timeline_manager.timelines() {
-		if timeline.stream_handle.is_none() && timeline.timeline_type.stream_params().is_some() {
+		if timeline.timeline_type.stream_params().is_some() {
 			handle.send(NetworkCommand::FetchTimeline {
 				timeline_type: timeline.timeline_type.clone(),
 				limit: Some(40),


### PR DESCRIPTION
## Summary
- The previous attempt at fixing #77 (fdc23ca) polled a timeline only when `timeline.stream_handle` was `None`. `start_streaming()` returns `Some(handle)` as soon as the background thread is spawned, not once a connection actually succeeds, and the retry loop keeps that same handle forever — so on instances where the streaming API isn't supported, or where the socket stays open without ever delivering events (confirmed on GoToSocial and Iceshrimp), the handle was always `Some` and the poll never fired.
- Rather than trying to track "real" connection/liveness state (unreliable across server implementations), the 60s timer now just unconditionally re-fetches every timeline of a streamable type, reusing the same fetch/replace code path that manual F5 refresh already uses successfully.

## Test plan
- [x] `cargo build`
- [x] Verified against an Iceshrimp instance (fed.interfree.ca) that previously never auto-refreshed: timeline now picks up new posts within 60s without pressing F5, and reading position/selection is preserved same as F5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)