### PR TITLE
Add Windows ARM64 builds to build and release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,16 @@ permissions:
   contents: write
 jobs:
   build:
-    runs-on: windows-latest
+    name: Build (${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            arch: x64
+          - os: windows-11-arm
+            arch: arm64
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -18,7 +27,7 @@ jobs:
     - name: Setup MSVC
       uses: ilammy/msvc-dev-cmd@v1
       with:
-        arch: x64
+        arch: ${{ matrix.arch }}
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:
@@ -40,28 +49,41 @@ jobs:
         [IO.File]::WriteAllText($keyPath, $env:MINISIGN_KEY)
         $pwPath = Join-Path $env:RUNNER_TEMP "fedra.pw"
         [IO.File]::WriteAllText($pwPath, $env:MINISIGN_PASSWORD)
-        Get-Content $pwPath | minisign -S -s $keyPath -m target/release/fedra_setup.exe
-        Get-Content $pwPath | minisign -S -s $keyPath -m target/release/fedra.zip
+        Get-Content $pwPath | minisign -S -s $keyPath -m target/release/fedra_setup_${{ matrix.arch }}.exe
+        Get-Content $pwPath | minisign -S -s $keyPath -m target/release/fedra_win_${{ matrix.arch }}.zip
         Remove-Item $keyPath, $pwPath
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: fedra-build
+        name: fedra-build-${{ matrix.arch }}
         path: |
-          target/release/fedra.zip
-          target/release/fedra.zip.minisig
-          target/release/fedra_setup.exe
-          target/release/fedra_setup.exe.minisig
+          target/release/fedra_win_${{ matrix.arch }}.zip
+          target/release/fedra_win_${{ matrix.arch }}.zip.minisig
+          target/release/fedra_setup_${{ matrix.arch }}.exe
+          target/release/fedra_setup_${{ matrix.arch }}.exe.minisig
         retention-days: 30
+  publish:
+    name: Publish latest release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: fedra-build-*
+        path: dist
+        merge-multiple: true
     - name: Get latest tag reachable from HEAD
       id: get_tag
-      shell: bash
       run: |
         TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
         echo "tag=$TAG" >> $GITHUB_OUTPUT
     - name: Generate release notes
       id: release_notes
-      shell: bash
       run: |
         PREV_TAG="${{ steps.get_tag.outputs.tag }}"
         if [ -z "$PREV_TAG" ]; then
@@ -81,11 +103,7 @@ jobs:
         body: |
           ## Commits since last release
           ${{ steps.release_notes.outputs.commits }}
-        files: |
-          target/release/fedra.zip
-          target/release/fedra.zip.minisig
-          target/release/fedra_setup.exe
-          target/release/fedra_setup.exe.minisig
+        files: dist/*
         prerelease: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,17 @@ on:
 permissions:
   contents: write
 jobs:
-  release:
-    runs-on: windows-latest
+  build:
+    name: Build (${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            arch: x64
+          - os: windows-11-arm
+            arch: arm64
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -17,7 +26,7 @@ jobs:
     - name: Setup MSVC
       uses: ilammy/msvc-dev-cmd@v1
       with:
-        arch: x64
+        arch: ${{ matrix.arch }}
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:
@@ -39,22 +48,36 @@ jobs:
         [IO.File]::WriteAllText($keyPath, $env:MINISIGN_KEY)
         $pwPath = Join-Path $env:RUNNER_TEMP "fedra.pw"
         [IO.File]::WriteAllText($pwPath, $env:MINISIGN_PASSWORD)
-        Get-Content $pwPath | minisign -S -s $keyPath -m target/release/fedra_setup.exe
-        Get-Content $pwPath | minisign -S -s $keyPath -m target/release/fedra.zip
+        Get-Content $pwPath | minisign -S -s $keyPath -m target/release/fedra_setup_${{ matrix.arch }}.exe
+        Get-Content $pwPath | minisign -S -s $keyPath -m target/release/fedra_win_${{ matrix.arch }}.zip
         Remove-Item $keyPath, $pwPath
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: fedra-release-${{ github.ref_name }}
+        name: fedra-release-${{ github.ref_name }}-${{ matrix.arch }}
         path: |
-          target/release/fedra.zip
-          target/release/fedra.zip.minisig
-          target/release/fedra_setup.exe
-          target/release/fedra_setup.exe.minisig
+          target/release/fedra_win_${{ matrix.arch }}.zip
+          target/release/fedra_win_${{ matrix.arch }}.zip.minisig
+          target/release/fedra_setup_${{ matrix.arch }}.exe
+          target/release/fedra_setup_${{ matrix.arch }}.exe.minisig
         retention-days: 90
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: fedra-release-${{ github.ref_name }}-*
+        path: dist
+        merge-multiple: true
     - name: Get previous tag
       id: prev_tag
-      shell: bash
       run: |
         PREV=$(git tag --sort=-version:refname | grep -v "^${{ github.ref_name }}$" | head -n 1 || echo "")
         echo "tag=$PREV" >> $GITHUB_OUTPUT
@@ -63,11 +86,7 @@ jobs:
       with:
         tag_name: ${{ github.ref_name }}
         name: ${{ github.ref_name }}
-        files: |
-          target/release/fedra.zip
-          target/release/fedra.zip.minisig
-          target/release/fedra_setup.exe
-          target/release/fedra_setup.exe.minisig
+        files: dist/*
         prerelease: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.rs
+++ b/build.rs
@@ -130,7 +130,12 @@ fn configure_installer() {
 		}
 	};
 	let version = env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0.0.0".to_string());
-	let new_content = content.replace("@PROJECT_VERSION@", &version);
+	let target = env::var("TARGET").unwrap_or_default();
+	let (arch_suffix, arch_iss) = if target.starts_with("aarch64") { ("arm64", "arm64") } else { ("x64", "x64compatible") };
+	let new_content = content
+		.replace("@PROJECT_VERSION@", &version)
+		.replace("@ARCH_SUFFIX@", arch_suffix)
+		.replace("@ARCH_ISS@", arch_iss);
 	let output_path = target_dir.join("fedra.iss");
 	if let Err(e) = fs::write(&output_path, new_content) {
 		println!("cargo:warning=Failed to write installer script: {e}");

--- a/fedra.iss.in
+++ b/fedra.iss.in
@@ -10,12 +10,13 @@
 	DisableDirPage=yes
 	LicenseFile=
 	OutputDir=.
-	OutputBaseFilename=fedra_setup
+	OutputBaseFilename=fedra_setup_@ARCH_SUFFIX@
 	Compression=lzma2
 	SolidCompression=yes
 	WizardStyle=modern
 	UninstallDisplayIcon={app}\fedra.exe
-	ArchitecturesInstallIn64BitMode=x64compatible
+	ArchitecturesAllowed=@ARCH_ISS@
+	ArchitecturesInstallIn64BitMode=@ARCH_ISS@
 
 [Languages]
 	Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -52,14 +52,26 @@ fn project_root() -> PathBuf {
 	Path::new(&env!("CARGO_MANIFEST_DIR")).ancestors().nth(1).unwrap().to_path_buf()
 }
 
+fn arch_suffix() -> &'static str {
+	match env::consts::ARCH {
+		"aarch64" => "arm64",
+		"x86_64" => "x64",
+		other => other,
+	}
+}
+
 fn build_zip_package(
 	target_dir: &Path,
 	exe_path: &Path,
 	readme_path: &Path,
 	sounds_dir: &Path,
 ) -> Result<(), Box<dyn Error>> {
-	let package_name = if cfg!(target_os = "macos") { "fedra_mac.zip" } else { "fedra.zip" };
-	let package_path = target_dir.join(package_name);
+	let package_name = if cfg!(target_os = "macos") {
+		"fedra_mac.zip".to_string()
+	} else {
+		format!("fedra_win_{}.zip", arch_suffix())
+	};
+	let package_path = target_dir.join(&package_name);
 	let file = File::create(&package_path)?;
 	let mut zip = ZipWriter::new(file);
 	let options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);


### PR DESCRIPTION
Adds native Windows on ARM (`aarch64-pc-windows-msvc`) builds alongside the existing x64 builds, using GitHub's `windows-11-arm` hosted runners.

## Why
Fedra currently only builds for Windows x64. This adds first-class arm64 support so users on Windows-on-ARM devices get a native build instead of running the x64 binary under emulation.

## Changes
* build.yml / release.yml: build jobs now matrix over x64/arm64; a new downstream job downloads both sets of artifacts and publishes a single combined release (avoids both arch jobs racing to update the same release simultaneously)
* xtask: zip package name is now arch-suffixed (`fedra_win_x64.zip` / `fedra_win_arm64.zip`) instead of a single `fedra.zip`, since both arches now build in the same CI run
*fedra.iss.in / build.rs: installer output name and Inno Setup architecture directives are now templated per-arch, so the arm64 installer is `fedra_setup_arm64.exe` and installs natively rather than in x64-compatible mode