### PR TITLE
ci: use hyphenated artifact filenames

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,18 +49,18 @@ jobs:
         [IO.File]::WriteAllText($keyPath, $env:MINISIGN_KEY)
         $pwPath = Join-Path $env:RUNNER_TEMP "fedra.pw"
         [IO.File]::WriteAllText($pwPath, $env:MINISIGN_PASSWORD)
-        Get-Content $pwPath | minisign -S -s $keyPath -m target/release/fedra_setup_${{ matrix.arch }}.exe
-        Get-Content $pwPath | minisign -S -s $keyPath -m target/release/fedra_win_${{ matrix.arch }}.zip
+        Get-Content $pwPath | minisign -S -s $keyPath -m target/release/fedra_setup-${{ matrix.arch }}.exe
+        Get-Content $pwPath | minisign -S -s $keyPath -m target/release/fedra-${{ matrix.arch }}.zip
         Remove-Item $keyPath, $pwPath
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
         name: fedra-build-${{ matrix.arch }}
         path: |
-          target/release/fedra_win_${{ matrix.arch }}.zip
-          target/release/fedra_win_${{ matrix.arch }}.zip.minisig
-          target/release/fedra_setup_${{ matrix.arch }}.exe
-          target/release/fedra_setup_${{ matrix.arch }}.exe.minisig
+          target/release/fedra-${{ matrix.arch }}.zip
+          target/release/fedra-${{ matrix.arch }}.zip.minisig
+          target/release/fedra_setup-${{ matrix.arch }}.exe
+          target/release/fedra_setup-${{ matrix.arch }}.exe.minisig
         retention-days: 30
   publish:
     name: Publish latest release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,18 +48,18 @@ jobs:
         [IO.File]::WriteAllText($keyPath, $env:MINISIGN_KEY)
         $pwPath = Join-Path $env:RUNNER_TEMP "fedra.pw"
         [IO.File]::WriteAllText($pwPath, $env:MINISIGN_PASSWORD)
-        Get-Content $pwPath | minisign -S -s $keyPath -m target/release/fedra_setup_${{ matrix.arch }}.exe
-        Get-Content $pwPath | minisign -S -s $keyPath -m target/release/fedra_win_${{ matrix.arch }}.zip
+        Get-Content $pwPath | minisign -S -s $keyPath -m target/release/fedra_setup-${{ matrix.arch }}.exe
+        Get-Content $pwPath | minisign -S -s $keyPath -m target/release/fedra-${{ matrix.arch }}.zip
         Remove-Item $keyPath, $pwPath
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
         name: fedra-release-${{ github.ref_name }}-${{ matrix.arch }}
         path: |
-          target/release/fedra_win_${{ matrix.arch }}.zip
-          target/release/fedra_win_${{ matrix.arch }}.zip.minisig
-          target/release/fedra_setup_${{ matrix.arch }}.exe
-          target/release/fedra_setup_${{ matrix.arch }}.exe.minisig
+          target/release/fedra-${{ matrix.arch }}.zip
+          target/release/fedra-${{ matrix.arch }}.zip.minisig
+          target/release/fedra_setup-${{ matrix.arch }}.exe
+          target/release/fedra_setup-${{ matrix.arch }}.exe.minisig
         retention-days: 90
   release:
     name: Publish release

--- a/fedra.iss.in
+++ b/fedra.iss.in
@@ -10,7 +10,7 @@
 	DisableDirPage=yes
 	LicenseFile=
 	OutputDir=.
-	OutputBaseFilename=fedra_setup_@ARCH_SUFFIX@
+	OutputBaseFilename=fedra_setup-@ARCH_SUFFIX@
 	Compression=lzma2
 	SolidCompression=yes
 	WizardStyle=modern

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -69,7 +69,7 @@ fn build_zip_package(
 	let package_name = if cfg!(target_os = "macos") {
 		"fedra_mac.zip".to_string()
 	} else {
-		format!("fedra_win_{}.zip", arch_suffix())
+		format!("fedra-{}.zip", arch_suffix())
 	};
 	let package_path = target_dir.join(&package_name);
 	let file = File::create(&package_path)?;


### PR DESCRIPTION
## Summary

Renames release artifacts to a consistent hyphenated naming scheme:

- `fedra_win_<arch>.zip` → `fedra-<arch>.zip`
- `fedra_setup_<arch>.exe` → `fedra_setup-<arch>.exe`

Updated `xtask/src/main.rs` and `fedra.iss.in` to produce the new filenames, and updated the sign/upload steps in `build.yml` and `release.yml` to match.