### PR TITLE
Use wx-utils' dialog helpers instead of local copies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,9 +2675,9 @@ checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wx-utils"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca8f45a9d19892be9147c5944b6e6862951a5f40f23bdc614d9fecf069224e9"
+checksum = "8c333d1cb5ae0ad1b27c44260bd789df253366ef59a81247578de6460df4148d"
 dependencies = [
  "patois",
  "wxdragon",
@@ -2685,9 +2685,9 @@ dependencies = [
 
 [[package]]
 name = "wxdragon"
-version = "0.9.19"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8615eada9f40db13be330cdbd65b34593bea8ec0016e77fe95d7a80d48d347"
+checksum = "dfd87ccbfebca6b9c831727e8e25135b4efdd6a8f6e18e88f86c0432757f01ed"
 dependencies = [
  "bitflags",
  "log",
@@ -2698,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "wxdragon-macros"
-version = "0.9.19"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385b4b0ca70c143597501aa1220532ed47f86f2d4d94b958f2236a4c5647223d"
+checksum = "4a97252fce1a2a824b2ba6f4156760be9a50160dcaed3ed1be3651388654e529"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -2710,9 +2710,9 @@ dependencies = [
 
 [[package]]
 name = "wxdragon-sys"
-version = "0.9.19"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802abf7d9fd64ab88f7bc9645e5ff6927d724961b939feef56d8b6e4d41e5f0b"
+checksum = "612465747e7c09f21a8e92f955d88c5e03c37271c4483aa644e2384e57bba9bd"
 dependencies = [
  "bindgen",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 tungstenite = { version = "0.30.0", features = ["rustls-tls-native-roots"] }
 url = "2.5.8"
-wx-utils = "0.1.2"
-wxdragon = { version = "0.9.19", features = ["media-ctrl", "webview"] }
+wx-utils = "0.2.0"
+wxdragon = { version = "0.9.20", features = ["media-ctrl", "webview"] }
 accesskit = "0.24.1"
 
 [target.'cfg(windows)'.dependencies]

--- a/src/ui/dialogs/common.rs
+++ b/src/ui/dialogs/common.rs
@@ -4,19 +4,7 @@ use crate::mastodon::SearchType;
 
 pub(crate) const KEY_RETURN: i32 = 13;
 
-pub fn prompt_text(frame: &Frame, message: &str, title: &str) -> Option<String> {
-	let dialog = TextEntryDialog::builder(frame, message, title)
-		.with_style(TextEntryDialogStyle::Default | TextEntryDialogStyle::ProcessEnter)
-		.build();
-	if dialog.show_modal() != ID_OK {
-		dialog.destroy();
-		return None;
-	}
-	let value = dialog.get_value().unwrap_or_default();
-	dialog.destroy();
-	let trimmed = value.trim();
-	if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
-}
+pub use wx_utils::prompt_text;
 
 #[derive(Clone, Copy)]
 pub enum UserLookupAction {
@@ -85,26 +73,13 @@ pub fn prompt_for_user_lookup(
 	Some((trimmed.to_string(), action))
 }
 
+/// Every error dialog in the app is titled with the app name, so this wraps the wx-utils
+/// helper rather than having each of the two dozen call sites repeat it.
 pub fn show_error(parent: &dyn WxWidget, err: &anyhow::Error) {
-	let dialog = MessageDialog::builder(parent, &err.to_string(), "Fedra")
-		.with_style(MessageDialogStyle::OK | MessageDialogStyle::IconError)
-		.build();
-	dialog.show_modal();
+	wx_utils::show_error(parent, err, "Fedra");
 }
 
-pub fn show_warning(frame: &Frame, message: &str, title: &str) {
-	let dialog = MessageDialog::builder(frame, message, title)
-		.with_style(MessageDialogStyle::OK | MessageDialogStyle::IconWarning)
-		.build();
-	dialog.show_modal();
-}
-
-pub fn show_warning_widget(parent: &dyn WxWidget, message: &str, title: &str) {
-	let dialog = MessageDialog::builder(parent, message, title)
-		.with_style(MessageDialogStyle::OK | MessageDialogStyle::IconWarning)
-		.build();
-	dialog.show_modal();
-}
+pub use wx_utils::show_warning;
 
 pub fn prompt_for_search(frame: &Frame) -> Option<(String, SearchType)> {
 	let dialog = Dialog::builder(frame, "Search").with_size(420, 200).build();

--- a/src/ui/dialogs/compose.rs
+++ b/src/ui/dialogs/compose.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, path::Path, rc::Rc};
 use chrono::{DateTime, Local, LocalResult, NaiveDate, NaiveTime, SecondsFormat, TimeZone, Utc};
 use wxdragon::prelude::*;
 
-use super::common::{KEY_RETURN, show_warning_widget};
+use super::common::{KEY_RETURN, show_warning};
 use crate::{
 	config::ContentWarningDisplay,
 	mastodon::{PollLimits, Status},
@@ -359,16 +359,16 @@ fn prompt_for_poll(
 	let mut options = options.borrow().clone();
 	options.retain(|option| !option.trim().is_empty());
 	if options.len() < 2 {
-		show_warning_widget(parent, "Polls need at least two options.", "Poll");
+		show_warning(parent, "Polls need at least two options.", "Poll");
 		return None;
 	}
 	if options.len() > limits.max_options {
-		show_warning_widget(parent, "Too many poll options for this instance.", "Poll");
+		show_warning(parent, "Too many poll options for this instance.", "Poll");
 		return None;
 	}
 	let selected_preset = duration_choice.get_selection().and_then(|i| presets_secs.get(i as usize).copied());
 	let Some(expires_in) = selected_preset else {
-		show_warning_widget(parent, "Please select a poll duration.", "Poll");
+		show_warning(parent, "Please select a poll duration.", "Poll");
 		return None;
 	};
 	Some(PollDialogResult::Updated(PostPoll {
@@ -764,12 +764,12 @@ fn prompt_for_schedule(parent: &dyn WxWidget, current: Option<&str>) -> Option<O
 		return Some(None);
 	}
 	let Some(scheduled_utc) = parse_schedule_inputs(&date_input.get_value(), &time_input.get_value()) else {
-		show_warning_widget(parent, "Enter date as YYYY-MM-DD and time as HH:MM.", "Invalid Schedule");
+		show_warning(parent, "Enter date as YYYY-MM-DD and time as HH:MM.", "Invalid Schedule");
 		return None;
 	};
 	let minimum = Utc::now() + chrono::Duration::minutes(5);
 	if scheduled_utc < minimum {
-		show_warning_widget(parent, "Scheduled time must be at least 5 minutes in the future.", "Invalid Schedule");
+		show_warning(parent, "Scheduled time must be at least 5 minutes in the future.", "Invalid Schedule");
 		return None;
 	}
 	Some(Some(scheduled_utc.to_rfc3339_opts(SecondsFormat::Secs, true)))
@@ -1031,9 +1031,9 @@ pub fn prompt_for_compose(
 		let content = content_text_ok.get_value();
 		let char_count = content.trim().chars().count();
 		if char_count > max_chars {
-			show_warning_widget(
+			show_warning(
 				&dialog_ok,
-				&format!("Post is {char_count} characters, which exceeds the {max_chars} character limit."),
+				format!("Post is {char_count} characters, which exceeds the {max_chars} character limit."),
 				&title_prefix_ok,
 			);
 		} else {
@@ -1059,9 +1059,9 @@ pub fn prompt_for_compose(
 				let content = content_text_enter.get_value();
 				let char_count = content.trim().chars().count();
 				if char_count > max_chars {
-					show_warning_widget(
+					show_warning(
 						&dialog_enter,
-						&format!("Post is {char_count} characters, which exceeds the {max_chars} character limit."),
+						format!("Post is {char_count} characters, which exceeds the {max_chars} character limit."),
 						&title_prefix_enter,
 					);
 				} else {


### PR DESCRIPTION
`src/ui/dialogs/common.rs` had four helpers that wx-utils already provides:

- **`prompt_text`** was a verbatim copy of `wx_utils::prompt_text` — now a re-export.
- **`show_warning` / `show_warning_widget`** were the same `MessageDialog` builder twice, differing only in `&Frame` vs `&dyn WxWidget`. wx-utils' signature covers both (`&Frame` coerces), so the 8 `show_warning_widget` call sites become plain `show_warning`.
- **`show_error`** stays as a thin wrapper, since every error dialog in the app is titled "Fedra" and that beats repeating it at 27 call sites.

wx-utils 0.2 requires wxdragon 0.9.20, so the manifest moves up to it explicitly rather than letting it resolve through wx-utils.

Two `show_warning(&format!(...))` arguments in `compose.rs` lost their borrows — 0.2's `show_warning` takes `impl Display`, matching `show_error`. Verified clippy sits at exactly the same 208 pre-existing findings as `main`, so this adds none.

Build clean, fmt clean, 11 tests passing.

Two follow-ups I did **not** do here, worth their own PRs:

1. **DPI.** `build.rs` declares `DpiAwareness::PerMonitorV2`, but the dialogs hardcode sizes like `.with_size(420, 180)`, so they open at two thirds of their intended size on a 150% display. `wx_utils::dpi::scale_size` is the fix, and it's mechanical but touches every dialog.
2. **`is_installer_distribution`** in `src/ui/update_check.rs` is byte-identical to paperback's. That belongs in ship-shape, which already takes the flag as a parameter.