### PR TITLE
Add per-event notification sounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .claude/
 /target
+
+# Sound packs are personal. Fedra ships none; see the Sounds tab.
+/sounds/packs/

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -8,6 +8,7 @@ Windows 10 or 11
 ## Core Features
 - Native Windows UI with screen-reader-friendly controls and live announcements, built on a custom [AccessKit](https://accesskit.dev)-backed list control.
 - Multi-account support, including account switching while preserving per-account timelines.
+- A separate notification sound for each kind of event, from mentions and direct messages to follows, boosts, and favorites. Fedra ships one sound and plays it for everything until you supply your own, one event at a time or a whole pack at once.
 - Timelines: Home, Notifications, Mentions, Sent, Local, another instance's Local, Federated, Direct Messages, Bookmarks, Favorites, Lists, User, Hashtag, Thread, and Search.
 - Real-time streaming for Home, Notifications, Local, Federated, Direct, and List timelines. Your own posts also appear in the Sent timeline as soon as you publish them.
 - Rich post creation and editing with:
@@ -117,6 +118,7 @@ Open options with `Ctrl+,`.
 - Notifications mode:
   - Classic Windows Notifications
   - Sound only
+  - Sound and notifications
   - Disabled
 - `Customize Keyboard Shortcuts...`
 - `Customize Window Hotkey...` (Ctrl/Alt/Shift/Win modifiers + custom key)
@@ -143,6 +145,92 @@ Open options with `Ctrl+,`.
 - `Customize Default Timelines...`
   - Home and Notifications are opened at startup
   - Any of Local, Federated, Direct Messages, Bookmarks, Favorites, Mentions, and Sent can be added
+
+### Sounds Tab
+Fedra can play a different sound for each kind of event, and every one of them is a file
+of your choosing.
+
+Fedra ships a single sound, `boop.mp3`, and every event falls back to it. A new install
+therefore sounds exactly as Fedra always has: one sound for everything. The moment you
+give an event a file of its own, that event uses it and the rest carry on with the
+fallback. No per-event audio is bundled, deliberately, so nothing here is anyone's taste
+but yours.
+
+- `Enable notification sounds`: master switch for every sound below.
+- `Sound pack`: the set of sounds to use. Switching packs changes every event at once,
+  while leaving anything you unchecked still unchecked. A pack that provides some but not
+  all of the sounds says so in the list; the events it leaves out fall back to the default
+  pack, and then to `boop.mp3`.
+- `Volume`: 0 to 100, applied to all sounds.
+- The sound list shows one entry per event, each with the file it currently uses.
+  Unchecking an entry silences just that event and leaves the rest alone.
+
+Sounds are tied to actions, not just to things arriving. Where an action has two
+directions, both share one sound: favoriting a post and having one of yours favorited
+are both the favorite sound. Undoing an action reuses its sound, since the point is to
+confirm something happened and the screen reader already says which way it went.
+
+| Event | When it plays |
+| --- | --- |
+| Mention | Someone mentions you in a public, unlisted, or followers-only post |
+| Direct message | Someone mentions you in a direct post |
+| New post in home timeline | Somebody you follow posts. The busiest event by far, so give it the shortest and quietest sound you have, or uncheck it to silence just this one |
+| Followed someone, or gained a follower | You follow or unfollow an account or hashtag, or somebody follows you |
+| Follow request | Somebody asks to follow you, or you accept or reject a request |
+| Favorited a post, or yours was favorited | Either direction |
+| Boosted a post, or yours was boosted | Either direction |
+| Bookmarked or unbookmarked a post | Your own bookmarking |
+| Pinned or unpinned a post | Your own pinning |
+| Poll ended | A poll you voted in has finished |
+| Voted in a poll | You cast a vote |
+| Edited a post, or one you follow was edited | Either direction |
+| Sent a post or reply | Your post or reply was published or scheduled |
+| Deleted a post | You deleted one of your posts |
+| Action failed | Any of the above failed |
+
+Blocking, muting, and hiding boosts have no sound, since borrowing the follow sound for
+them would be misleading and the screen reader announces them anyway.
+
+Sounds for things that *arrive* (mentions, direct messages, new home posts, and
+notifications that somebody favorited, boosted, followed, or edited) follow the
+notification mode on the General tab: they play in `Sound only` and `Sound and
+notifications`, and are silent in `Classic Windows Notifications` or `Disabled`.
+
+Sounds for things *you do* always play, subject only to this tab, because they confirm
+an action you just took rather than announcing something that arrived.
+
+Buttons under the list:
+
+- `Play`: hear the selected event's sound. This works even when the event is unchecked,
+  so you can audition a sound before switching it back on.
+- `Change...`: pick any `.mp3`, `.wav`, `.ogg`, `.flac`, `.m4a`, `.aac`, or `.opus` file.
+  Choosing a file also re-checks that event.
+- `Reset`: hand the selected event back to the active pack, dropping any file you chose for it.
+- `Reset all`: hand every event back to the active pack.
+- `Open sounds folder`: open your personal sound folder, creating it and a `packs` folder
+  inside it if they are not there yet, along with a readme listing the filename each event
+  answers to.
+
+### Sound Packs
+
+A pack is a folder of sounds named after the events they play for, such as `mention.mp3`
+and `follow.mp3`. Packs live under `packs` in your personal sound folder.
+
+Fedra ships no packs. To make one, press `Open sounds folder`, create a folder under
+`packs`, name it whatever you like, and put your files in it. It appears in the
+`Sound pack` list the next time you open the options. The readme in that folder lists
+every filename Fedra looks for.
+
+A pack may use `.mp3`, `.wav`, `.ogg`, `.flac`, or `.m4a`. A pack does not have to be
+complete: any event it does not provide falls back to `boop.mp3`, so a pack of one file
+is perfectly valid.
+
+Picking a file with `Change...` overrides the pack for that one event and survives
+switching packs, until you press `Reset` to hand the event back to the pack.
+
+Updating Fedra never touches your sound folder, so your packs and edits survive an
+upgrade.
+
 
 ### Templates Tab
 Customize how posts appear in each timeline using [Jinja2-style](https://jinja.palletsprojects.com/en/stable/templates/) templates.
@@ -360,7 +448,32 @@ Press `Ctrl+I` (or `I` in Quick Action Keys mode) on a post with media attachmen
 - Installed build: `%APPDATA%\Fedra\config.json`
 - Portable/uninstalled run: `config.json` next to the executable
 
+Sound settings live under the `sounds` key: `enabled` is the master switch, `volume` is 0 to 100,
+`pack` names the active pack, and `events` maps an event name to its `enabled` flag and `file`. An
+empty `file` means the event takes its sound from the pack, or from `boop.mp3` if the pack
+does not provide one; a bare name is looked up in your `sounds` folder and then in Fedra's,
+and an absolute path is used as given.
+
 ## Changelog
+
+### Unreleased
+* Added per-event notification sounds. Mentions, direct messages, new home-timeline posts, new
+  followers, follow requests, favorites, boosts, bookmarks, pins, ended polls, poll votes, edited
+  posts, sent posts, deleted posts, and failures each have their own sound instead of sharing a
+  single beep.
+* Sounds are tied to actions in both directions, so favoriting a post and having one of yours
+  favorited play the same sound, as do boosting, following, and editing.
+* Added a Sounds tab to the options dialog for setting the master switch, the volume, and the sound
+  used by each event, with a Play button to audition one and a file picker to replace it.
+* Added a `Sound and notifications` notification mode, for a Windows notification and a sound
+  together.
+* Added sound packs, so a whole set of sounds can be swapped in one step rather than fifteen
+  files at a time. A pack is a folder of files named after the events they play for.
+* No per-event audio is bundled. Every event falls back to the existing `boop.mp3`, so an
+  untouched install sounds exactly as it did before, and the sounds you do hear are ones you
+  chose.
+* Custom sounds and packs are read from `sounds` in your configuration folder, which takes
+  precedence over the sounds Fedra ships with and is left alone by updates.
 
 ### Version 0.5.0
 * Account usernames are now properly resolved when replying to a post from a remote instance's local timeline.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use std::{
-	collections::HashMap,
+	collections::{BTreeMap, HashMap},
 	env, fs, io,
 	path::{Path, PathBuf},
 	time::{SystemTime, UNIX_EPOCH},
@@ -46,6 +46,8 @@ pub struct Config {
 	pub default_timelines: Vec<DefaultTimeline>,
 	#[serde(default)]
 	pub notification_preference: NotificationPreference,
+	#[serde(default)]
+	pub sounds: SoundSettings,
 	#[serde(default = "default_check_for_updates")]
 	pub check_for_updates_on_startup: bool,
 	#[serde(default)]
@@ -102,6 +104,105 @@ pub enum NotificationPreference {
 	Classic,
 	SoundOnly,
 	Disabled,
+	/// Show a Windows notification *and* play the sound for the event.
+	SoundAndClassic,
+}
+
+impl NotificationPreference {
+	/// Whether this mode shows a desktop notification.
+	#[must_use]
+	pub const fn shows_toast(self) -> bool {
+		matches!(self, Self::Classic | Self::SoundAndClassic)
+	}
+
+	/// Whether this mode plays a sound.
+	#[must_use]
+	pub const fn plays_sound(self) -> bool {
+		matches!(self, Self::SoundOnly | Self::SoundAndClassic)
+	}
+}
+
+/// Sound chosen for a single event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventSound {
+	/// Whether this event plays a sound at all.
+	pub enabled: bool,
+	/// A bare file name resolved against the sound directories, or an absolute path.
+	pub file: String,
+}
+
+/// Name of the sound pack used when none is configured.
+///
+/// Fedra ships no pack, so nothing on disk answers to this until the user makes one. It stays
+/// the name every other pack falls back to, and the name the Sounds tab shows when the folder is
+/// still empty.
+pub const DEFAULT_SOUND_PACK: &str = "default";
+
+fn default_sound_pack() -> String {
+	DEFAULT_SOUND_PACK.to_string()
+}
+
+/// Notification sound settings.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SoundSettings {
+	/// Master switch; when false no event plays a sound.
+	pub enabled: bool,
+	/// Playback volume, 0-100.
+	pub volume: u8,
+	/// Folder name of the active sound pack.
+	#[serde(default = "default_sound_pack")]
+	pub pack: String,
+	/// Per-event overrides, keyed by [`crate::sounds::SoundEvent::key`].
+	///
+	/// An entry with an empty `file` takes its sound from the active pack, so switching packs
+	/// keeps any per-event muting the user has set up.
+	pub events: BTreeMap<String, EventSound>,
+}
+
+impl Default for SoundSettings {
+	fn default() -> Self {
+		Self { enabled: true, volume: 80, pack: default_sound_pack(), events: BTreeMap::new() }
+	}
+}
+
+impl SoundSettings {
+	/// Settings for `event`, falling back to the shipped defaults when unset.
+	///
+	/// The default `file` is empty, meaning the active pack supplies the sound.
+	#[must_use]
+	pub fn for_event(&self, event: crate::sounds::SoundEvent) -> EventSound {
+		self.events
+			.get(event.key())
+			.cloned()
+			.unwrap_or_else(|| EventSound { enabled: event.default_enabled(), file: String::new() })
+	}
+
+	/// Whether `event` should make a sound at all.
+	#[must_use]
+	pub fn plays(&self, event: crate::sounds::SoundEvent) -> bool {
+		self.enabled && self.for_event(event).enabled
+	}
+
+	/// The file to play for `event`, or `None` when it is silenced or has no sound on disk.
+	///
+	/// An explicit per-event file wins; otherwise the active pack is consulted, and finally the
+	/// default pack, so a pack missing one sound falls back rather than going silent.
+	#[must_use]
+	pub fn file_for(&self, event: crate::sounds::SoundEvent) -> Option<String> {
+		if !self.plays(event) {
+			return None;
+		}
+		let setting = self.for_event(event);
+		if !setting.file.trim().is_empty() {
+			return Some(setting.file);
+		}
+		crate::sounds::SoundPlayer::pack_file(&self.pack, event)
+	}
+
+	/// Replace the settings for `event`.
+	pub fn set_event(&mut self, event: crate::sounds::SoundEvent, setting: EventSound) {
+		self.events.insert(event.key().to_string(), setting);
+	}
 }
 
 #[allow(clippy::struct_excessive_bools)]
@@ -1025,6 +1126,7 @@ impl Default for Config {
 			preserve_thread_order: true,
 			default_timelines: default_timelines(),
 			notification_preference: NotificationPreference::default(),
+			sounds: SoundSettings::default(),
 			check_for_updates_on_startup: true,
 			update_channel: UpdateChannel::default(),
 			hotkey: HotkeyConfig::default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod mastodon;
 mod network;
 mod notifications;
 mod responses;
+mod sounds;
 mod streaming;
 mod template;
 mod text;
@@ -106,7 +107,7 @@ pub(crate) struct AppState {
 	pub(crate) current_user_id: Option<String>,
 	pub(crate) app_shell: Option<Rc<ui::app_shell::AppShell>>,
 	pub(crate) context_menu_state: Rc<Cell<ContextMenuState>>,
-	pub(crate) media_ctrl: Option<MediaCtrl>,
+	pub(crate) sound_player: Option<std::rc::Rc<crate::sounds::SoundPlayer>>,
 	pub(crate) ui_waker: UiWaker,
 	pub(crate) _instance_checker: Option<SingleInstanceChecker>,
 	pub(crate) pending_thread_continuation: bool,
@@ -140,7 +141,7 @@ impl AppState {
 			current_user_id: None,
 			app_shell: None,
 			context_menu_state: Rc::new(Cell::new(ContextMenuState::default())),
-			media_ctrl: None,
+			sound_player: None,
 			ui_waker,
 			_instance_checker: instance_checker,
 			pending_thread_continuation: false,
@@ -168,14 +169,6 @@ impl AppState {
 	pub(crate) fn timeline_view_options_for(&self, timeline_type: &timeline::TimelineType) -> TimelineViewOptions {
 		TimelineViewOptions::from_config(&self.config, timeline_type)
 	}
-}
-
-#[must_use]
-pub fn get_sound_path() -> std::path::PathBuf {
-	std::env::current_exe()
-		.ok()
-		.and_then(|path| path.parent().map(|p| p.join("sounds").join("boop.mp3")))
-		.unwrap_or_else(|| std::path::PathBuf::from("sounds/boop.mp3"))
 }
 
 fn drain_ui_commands(ui_rx: &mpsc::Receiver<UiCommand>, ctx: &mut UiCommandContext<'_>) {
@@ -230,12 +223,11 @@ fn main() {
 		let sort_order_cell = Rc::new(Cell::new(config.sort_order));
 		let shortcuts_cell = Rc::new(std::cell::RefCell::new(config.shortcuts.clone()));
 		let mut state = AppState::new(config, ui_waker.clone(), instance_checker);
-		let mc = MediaCtrl::builder(&frame).with_size(Size::new(0, 0)).build();
-		let sound_path = get_sound_path();
-		if sound_path.exists() {
-			mc.load(&sound_path.to_string_lossy());
-		}
-		state.media_ctrl = Some(mc);
+		let sound_player = std::rc::Rc::new(crate::sounds::SoundPlayer::new(frame));
+		sound_player.set_volume(state.config.sounds.volume);
+		// Load every sound now so the controls are ready long before the first notification.
+		sound_player.preload(&state.config.sounds);
+		state.sound_player = Some(sound_player);
 		if state.config.accounts.is_empty() && !start_add_account_flow(&frame, &ui_tx, &mut state) {
 			frame.close(true);
 			return;

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -81,6 +81,44 @@ fn merge_status_snapshot(state: &mut AppState, snapshot: &Status) -> bool {
 	updated
 }
 
+/// Play the sound configured for `event`, if any.
+///
+/// Takes the settings and player separately rather than all of [`AppState`], because the
+/// streaming loop already holds a mutable borrow of `state.timeline_manager` while it calls this.
+///
+/// Silently does nothing when sounds are disabled, the event is muted, or the file is missing.
+pub fn play_sound(
+	settings: &crate::config::SoundSettings,
+	player: Option<&std::rc::Rc<crate::sounds::SoundPlayer>>,
+	event: crate::sounds::SoundEvent,
+) {
+	if let Some(file) = settings.file_for(event)
+		&& let Some(player) = player
+	{
+		player.play(event, &file);
+	}
+}
+
+/// Pick the sound for an incoming notification and play it.
+///
+/// A mention carried by a direct-visibility post is treated as a direct message, so DMs are
+/// distinguishable from ordinary mentions by ear.
+fn play_notification_sound(
+	settings: &crate::config::SoundSettings,
+	player: Option<&std::rc::Rc<crate::sounds::SoundPlayer>>,
+	notification: &crate::mastodon::Notification,
+) {
+	let Some(mut event) = crate::sounds::SoundEvent::from_notification_kind(&notification.kind) else {
+		return;
+	};
+	if event == crate::sounds::SoundEvent::Mention
+		&& notification.status.as_ref().is_some_and(|s| s.visibility == "direct")
+	{
+		event = crate::sounds::SoundEvent::DirectMessage;
+	}
+	play_sound(settings, player, event);
+}
+
 /// Processes streaming events from WebSocket connections.
 pub fn process_stream_events(
 	state: &mut AppState,
@@ -121,6 +159,19 @@ pub fn process_stream_events(
 					// user timelines have no stream of their own, so forward them by hand.
 					if timeline_type == TimelineType::Home && current_user_id == Some(status.account.id.as_str()) {
 						own_post_forwards.push(status.clone());
+					} else if timeline_type == TimelineType::Home
+						// Matching the draining timeline as well keeps this to one sound per post,
+						// since a single stream handle can emit events for several timelines.
+						&& timeline.timeline_type == timeline_type
+						&& state.config.notification_preference.plays_sound()
+						&& !status.should_hide(&filter_context)
+						&& status.matches_filter(&timeline_filter, current_user_id)
+					{
+						play_sound(
+							&state.config.sounds,
+							state.sound_player.as_ref(),
+							crate::sounds::SoundEvent::HomePost,
+						);
 					}
 					if timeline.timeline_type == timeline_type
 						&& !status.should_hide(&filter_context)
@@ -153,19 +204,17 @@ pub fn process_stream_events(
 					if timeline.timeline_type == timeline_type {
 						if !processed_notification_ids.contains(&notification.id) {
 							let pref = state.config.notification_preference;
-							match pref {
-								crate::config::NotificationPreference::Classic => {
-									if let Some(app_shell) = &state.app_shell {
-										crate::notifications::show_notification(app_shell, &notification);
-									}
-								}
-								crate::config::NotificationPreference::SoundOnly => {
-									if let Some(mc) = &state.media_ctrl {
-										mc.stop();
-										mc.play();
-									}
-								}
-								crate::config::NotificationPreference::Disabled => {}
+							if pref.shows_toast()
+								&& let Some(app_shell) = &state.app_shell
+							{
+								crate::notifications::show_notification(app_shell, &notification);
+							}
+							if pref.plays_sound() {
+								play_notification_sound(
+									&state.config.sounds,
+									state.sound_player.as_ref(),
+									&notification,
+								);
 							}
 							processed_notification_ids.insert(notification.id.clone());
 						}
@@ -314,6 +363,54 @@ pub struct NetworkResponseContext<'a> {
 
 /// Processes network responses from the background network thread.
 #[allow(clippy::too_many_lines)]
+/// The sound for a completed action, if it has one.
+///
+/// Fedra performs an action by sending a request and reacting to the response, so every action the
+/// user takes ends up here. Mapping them in one place means a new action cannot silently miss its
+/// sound, and it keeps each direction of a pair on the same sound: favoriting a post and having
+/// one of yours favorited both play the favorite sound.
+///
+/// Undoing an action reuses its sound rather than having one of its own, since the point is to
+/// confirm that something happened; the screen reader already says which way it went.
+fn action_sound(response: &NetworkResponse) -> Option<crate::sounds::SoundEvent> {
+	use crate::sounds::SoundEvent as S;
+	let sound = |ok: bool, event: S| Some(if ok { event } else { S::Error });
+	match response {
+		NetworkResponse::Favorited { result, .. } | NetworkResponse::Unfavorited { result, .. } => {
+			sound(result.is_ok(), S::Favorite)
+		}
+		NetworkResponse::Boosted { result, .. } | NetworkResponse::Unboosted { result, .. } => {
+			sound(result.is_ok(), S::Boost)
+		}
+		NetworkResponse::Bookmarked { result, .. } | NetworkResponse::Unbookmarked { result, .. } => {
+			sound(result.is_ok(), S::Bookmark)
+		}
+		NetworkResponse::Pinned { result, .. } | NetworkResponse::Unpinned { result, .. } => {
+			sound(result.is_ok(), S::Pin)
+		}
+		NetworkResponse::PollVoted { result } => sound(result.is_ok(), S::PollVoted),
+		NetworkResponse::StatusDeleted { result, .. } => sound(result.is_ok(), S::PostDeleted),
+		NetworkResponse::StatusEdited { result, .. } => sound(result.is_ok(), S::PostEdited),
+		NetworkResponse::PostComplete(result) | NetworkResponse::Replied(result) => sound(result.is_ok(), S::PostSent),
+		NetworkResponse::TagFollowed { result, .. } | NetworkResponse::TagUnfollowed { result, .. } => {
+			sound(result.is_ok(), S::Follow)
+		}
+		// Only the follow-shaped relationship changes get a sound. Blocking, muting, and hiding
+		// boosts are different enough that borrowing the follow sound would be misleading, and the
+		// screen reader already announces them.
+		NetworkResponse::RelationshipUpdated { action, result, .. } => {
+			use crate::network::RelationshipAction as A;
+			let event = match action {
+				A::Follow | A::Unfollow | A::CancelFollowRequest => Some(S::Follow),
+				A::AcceptFollowRequest | A::RejectFollowRequest => Some(S::FollowRequest),
+				A::Block | A::Unblock | A::Mute | A::Unmute | A::ShowBoosts | A::HideBoosts => None,
+			};
+			event.and_then(|event| sound(result.is_ok(), event))
+		}
+		_ => None,
+	}
+}
+
 pub fn process_network_responses(ctx: &mut NetworkResponseContext<'_>) {
 	let frame = ctx.frame;
 	let state = &mut *ctx.state;
@@ -349,6 +446,11 @@ pub fn process_network_responses(ctx: &mut NetworkResponseContext<'_>) {
 		}};
 	}
 	for response in handle.drain() {
+		// Action sounds are deliberately not gated on the notification preference: they confirm
+		// something the user just did, rather than announcing something that arrived.
+		if let Some(event) = action_sound(&response) {
+			play_sound(&state.config.sounds, state.sound_player.as_ref(), event);
+		}
 		match response {
 			NetworkResponse::TimelineLoaded { timeline_type, result: Ok(data), max_id } => {
 				let mut should_find_next = false;

--- a/src/sounds.rs
+++ b/src/sounds.rs
@@ -1,0 +1,531 @@
+//! Per-event notification sounds.
+//!
+//! Fedra historically played a single `sounds/boop.mp3` for every notification. This module
+//! keeps that as the fallback and lets each event take a sound of its own instead, independently
+//! switchable by the user. No per-event audio is bundled: the sounds are whatever the user puts
+//! in their sounds folder, so an untouched install behaves exactly as it always did.
+//!
+//! Playback uses one [`MediaCtrl`] per event. `MediaCtrl::load` is asynchronous and the backend
+//! does not reliably deliver a `Loaded` event, so nothing here waits for one: controls are loaded
+//! up front by [`SoundPlayer::preload`] at startup, exactly as the single-sound implementation
+//! did, and playing is then just stop-then-play. A control created later, because the user picked
+//! a different file, is played immediately and retried from the `Loaded` handler if that event
+//! does happen to arrive.
+//!
+//! Volume can only be set once a file is loaded, so it is applied after `load` and again on every
+//! play rather than once at construction.
+
+use std::{
+	cell::{Cell, RefCell},
+	collections::HashMap,
+	path::{Path, PathBuf},
+	rc::Rc,
+};
+
+use wxdragon::prelude::*;
+
+/// A user-facing event that can have its own sound.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SoundEvent {
+	Mention,
+	DirectMessage,
+	HomePost,
+	Follow,
+	FollowRequest,
+	Favorite,
+	Boost,
+	Bookmark,
+	Pin,
+	PollEnded,
+	PollVoted,
+	PostEdited,
+	PostSent,
+	PostDeleted,
+	Error,
+}
+
+impl SoundEvent {
+	/// Every event, in the order they are listed in the options dialog.
+	pub const ALL: [Self; 15] = [
+		Self::Mention,
+		Self::DirectMessage,
+		Self::HomePost,
+		Self::Follow,
+		Self::FollowRequest,
+		Self::Favorite,
+		Self::Boost,
+		Self::Bookmark,
+		Self::Pin,
+		Self::PollEnded,
+		Self::PollVoted,
+		Self::PostEdited,
+		Self::PostSent,
+		Self::PostDeleted,
+		Self::Error,
+	];
+
+	/// Stable identifier used as the config key and as the default file stem.
+	#[must_use]
+	pub const fn key(self) -> &'static str {
+		match self {
+			Self::Mention => "mention",
+			Self::DirectMessage => "direct_message",
+			Self::HomePost => "home_post",
+			Self::Follow => "follow",
+			Self::FollowRequest => "follow_request",
+			Self::Favorite => "favorite",
+			Self::Boost => "boost",
+			Self::Bookmark => "bookmark",
+			Self::Pin => "pin",
+			Self::PollEnded => "poll_ended",
+			Self::PollVoted => "poll_voted",
+			Self::PostEdited => "post_edited",
+			Self::PostSent => "post_sent",
+			Self::PostDeleted => "post_deleted",
+			Self::Error => "error",
+		}
+	}
+
+	/// Human-readable name shown in the options dialog.
+	#[must_use]
+	pub const fn label(self) -> &'static str {
+		match self {
+			Self::Mention => "Mention",
+			Self::DirectMessage => "Direct message",
+			Self::HomePost => "New post in home timeline",
+			Self::Follow => "Followed someone, or gained a follower",
+			Self::FollowRequest => "Follow request",
+			Self::Favorite => "Favorited a post, or yours was favorited",
+			Self::Boost => "Boosted a post, or yours was boosted",
+			Self::Bookmark => "Bookmarked or unbookmarked a post",
+			Self::Pin => "Pinned or unpinned a post",
+			Self::PollEnded => "Poll ended",
+			Self::PollVoted => "Voted in a poll",
+			Self::PostEdited => "Edited a post, or one you follow was edited",
+			Self::PostSent => "Sent a post or reply",
+			Self::PostDeleted => "Deleted a post",
+			Self::Error => "Action failed",
+		}
+	}
+
+	/// Conventional filename for this event inside a sound pack.
+	#[must_use]
+	pub fn default_file(self) -> String {
+		format!("{}.mp3", self.key())
+	}
+
+	/// Whether this event makes a sound out of the box.
+	///
+	/// Every event starts enabled. Home-timeline posts are the one that can fire continuously on a
+	/// busy feed, so its sound is deliberately the quietest and shortest of the set; unchecking it
+	/// in the Sounds tab silences it without touching the rest.
+	#[must_use]
+	pub const fn default_enabled(self) -> bool {
+		let _ = self;
+		true
+	}
+
+	/// Map a Mastodon notification `type` onto a sound.
+	///
+	/// Returns `None` for kinds Fedra has no sound for, so new server-side notification types
+	/// stay silent rather than borrowing another event's sound.
+	#[must_use]
+	pub fn from_notification_kind(kind: &str) -> Option<Self> {
+		match kind {
+			"mention" => Some(Self::Mention),
+			"status" => Some(Self::HomePost),
+			"follow" => Some(Self::Follow),
+			"follow_request" => Some(Self::FollowRequest),
+			"favourite" | "favorite" => Some(Self::Favorite),
+			"reblog" => Some(Self::Boost),
+			"poll" => Some(Self::PollEnded),
+			"update" => Some(Self::PostEdited),
+			_ => None,
+		}
+	}
+}
+
+/// One [`MediaCtrl`] and the file it holds.
+struct Slot {
+	ctrl: MediaCtrl,
+	path: PathBuf,
+}
+
+/// Owns the media controls used for notification sounds.
+pub struct SoundPlayer {
+	parent: Frame,
+	slots: RefCell<HashMap<SoundEvent, Slot>>,
+	/// Shared so the deferred `Loaded` handlers pick up later volume changes.
+	volume: Rc<Cell<f64>>,
+}
+
+impl SoundPlayer {
+	/// Create a player whose controls will be parented to `parent`.
+	#[must_use]
+	pub fn new(parent: Frame) -> Self {
+		Self { parent, slots: RefCell::new(HashMap::new()), volume: Rc::new(Cell::new(0.8)) }
+	}
+
+	/// Directory installed alongside the executable, holding [`Self::FALLBACK_FILE`].
+	#[must_use]
+	pub fn bundled_dir() -> PathBuf {
+		std::env::current_exe()
+			.ok()
+			.and_then(|path| path.parent().map(|p| p.join("sounds")))
+			.unwrap_or_else(|| PathBuf::from("sounds"))
+	}
+
+	/// Per-user sound directory, which takes precedence over the bundled one.
+	///
+	/// Custom sounds live here so that reinstalling or updating Fedra, which overwrites the
+	/// bundled directory, cannot delete them.
+	#[must_use]
+	pub fn user_dir() -> PathBuf {
+		crate::config::config_dir().join("sounds")
+	}
+
+	/// Resolve a configured sound value to a file on disk.
+	///
+	/// Absolute paths are used verbatim; bare names are looked up in the user directory first and
+	/// then in the bundled one.
+	#[must_use]
+	pub fn resolve(file: &str) -> Option<PathBuf> {
+		if file.trim().is_empty() {
+			return None;
+		}
+		let as_path = Path::new(file);
+		if as_path.is_absolute() {
+			return as_path.exists().then(|| as_path.to_path_buf());
+		}
+		let user = Self::user_dir().join(file);
+		if user.exists() {
+			return Some(user);
+		}
+		let bundled = Self::bundled_dir().join(file);
+		bundled.exists().then_some(bundled)
+	}
+
+	/// Extensions a sound may use, in the order they are tried.
+	const EXTENSIONS: [&'static str; 5] = ["mp3", "wav", "ogg", "flac", "m4a"];
+
+	/// The two folders packs are read from, personal first so it can shadow a shipped pack.
+	fn pack_roots() -> [PathBuf; 2] {
+		[Self::user_dir().join("packs"), Self::bundled_dir().join("packs")]
+	}
+
+	/// The one sound Fedra ships, played by any event nothing else provides.
+	///
+	/// Fedra has always played this file for every notification, and it stays the fallback so a
+	/// fresh install sounds exactly as it did before per-event sounds existed. Nothing is bundled
+	/// per event on purpose: the point of the feature is that the sounds are the user's own, and a
+	/// fixed set would both impose one person's taste and put redistribution terms on the
+	/// repository that it should not have to carry.
+	pub const FALLBACK_FILE: &'static str = "boop.mp3";
+
+	/// Path to `event`'s sound, from the pack if it has one.
+	///
+	/// Tries `pack`, then the default pack, so a pack missing a sound borrows it rather than
+	/// leaving that event silent, and finally [`Self::FALLBACK_FILE`]. An event is therefore
+	/// silent only when the user has switched it off.
+	#[must_use]
+	pub fn pack_file(pack: &str, event: SoundEvent) -> Option<String> {
+		Self::pack_file_exact(pack, event)
+			.or_else(|| {
+				(pack != crate::config::DEFAULT_SOUND_PACK)
+					.then(|| Self::pack_file_exact(crate::config::DEFAULT_SOUND_PACK, event))
+					.flatten()
+			})
+			.or_else(|| Some(Self::FALLBACK_FILE.to_string()))
+	}
+
+	/// Path to `event`'s sound in `pack` only, without falling back to another pack.
+	#[must_use]
+	pub fn pack_file_exact(pack: &str, event: SoundEvent) -> Option<String> {
+		if pack.trim().is_empty() {
+			return None;
+		}
+		for root in Self::pack_roots() {
+			for extension in Self::EXTENSIONS {
+				let candidate = root.join(pack).join(format!("{}.{extension}", event.key()));
+				if candidate.exists() {
+					return Some(candidate.to_string_lossy().into_owned());
+				}
+			}
+		}
+		// Older layouts kept the sounds loose in the sounds folder rather than in a pack.
+		if pack == crate::config::DEFAULT_SOUND_PACK {
+			for root in [Self::user_dir(), Self::bundled_dir()] {
+				let candidate = root.join(event.default_file());
+				if candidate.exists() {
+					return Some(candidate.to_string_lossy().into_owned());
+				}
+			}
+		}
+		None
+	}
+
+	/// Every pack found on disk, sorted, with the default first if present.
+	#[must_use]
+	pub fn list_packs() -> Vec<String> {
+		let mut packs: Vec<String> = Vec::new();
+		for root in Self::pack_roots() {
+			let Ok(entries) = std::fs::read_dir(&root) else { continue };
+			for entry in entries.flatten() {
+				if !entry.path().is_dir() {
+					continue;
+				}
+				let Some(name) = entry.file_name().to_str().map(str::to_owned) else { continue };
+				if !packs.contains(&name) {
+					packs.push(name);
+				}
+			}
+		}
+		packs.sort_by_key(|name| (name != crate::config::DEFAULT_SOUND_PACK, name.to_lowercase()));
+		if packs.is_empty() {
+			packs.push(crate::config::DEFAULT_SOUND_PACK.to_string());
+		}
+		packs
+	}
+
+	/// How many of the events `pack` actually provides, used to warn about an incomplete pack.
+	#[must_use]
+	pub fn pack_coverage(pack: &str) -> usize {
+		SoundEvent::ALL.iter().filter(|event| Self::pack_file_exact(pack, **event).is_some()).count()
+	}
+
+	/// Turn a pack folder name into something worth reading aloud.
+	#[must_use]
+	pub fn pack_display_name(pack: &str) -> String {
+		let mut out = String::with_capacity(pack.len());
+		for (index, word) in pack.split(['_', '-']).filter(|w| !w.is_empty()).enumerate() {
+			if index > 0 {
+				out.push(' ');
+			}
+			let mut chars = word.chars();
+			if let Some(first) = chars.next() {
+				out.extend(first.to_uppercase());
+				out.push_str(chars.as_str());
+			}
+		}
+		if out.is_empty() { pack.to_string() } else { out }
+	}
+
+	/// Create the user sound folder, and the `packs` folder inside it, with a readme.
+	///
+	/// Fedra bundles no per-event audio, so the folder starts empty and the readme has to do the
+	/// explaining: which names the events answer to, and what to drop in. Opening a bare folder
+	/// with no hint of either is the failure this avoids. Existing files are never overwritten.
+	///
+	/// Returns the folder either way, so a failure to seed still opens something.
+	pub fn seed_user_dir() -> PathBuf {
+		let dir = Self::user_dir();
+		if std::fs::create_dir_all(&dir).is_err() {
+			return dir;
+		}
+		let _ = std::fs::create_dir_all(dir.join("packs"));
+		let readme = dir.join("readme.txt");
+		if !readme.exists() {
+			let names = SoundEvent::ALL.iter().map(|event| event.default_file()).collect::<Vec<_>>().join("\r\n  ");
+			let _ = std::fs::write(
+				&readme,
+				format!(
+					"Fedra notification sounds\r\n\
+					 \r\n\
+					 Fedra ships one sound, {fallback}, and plays it for every event until you say \
+					 otherwise. Anything you put here takes its place.\r\n\
+					 \r\n\
+					 To change one event, use Change in the Sounds tab and point it at any file on \
+					 disk.\r\n\
+					 \r\n\
+					 To change them all at once, make a pack: create a folder under packs, name it \
+					 whatever you like, and put files in it named after the events they play for. It \
+					 appears in the Sound pack list the next time you open the options. A pack may \
+					 use mp3, wav, ogg, flac, or m4a, and any event a pack does not provide falls \
+					 back to {fallback} rather than going silent, so a pack of one file is perfectly \
+					 valid.\r\n\
+					 \r\n\
+					 The names, one per event:\r\n\
+					 \r\n  {names}\r\n\
+					 \r\n\
+					 This folder is yours. Updating Fedra never touches it.\r\n",
+					fallback = Self::FALLBACK_FILE,
+				),
+			);
+		}
+		dir
+	}
+
+	/// Set the output volume for every current and future sound. `volume` is 0-100.
+	pub fn set_volume(&self, volume: u8) {
+		let scaled = f64::from(volume.min(100)) / 100.0;
+		self.volume.set(scaled);
+		for slot in self.slots.borrow().values() {
+			slot.ctrl.set_volume(scaled);
+		}
+	}
+
+	/// Load a control for every event that has a usable sound file.
+	///
+	/// Called at startup so a control is fully loaded well before the first notification, which is
+	/// what makes playback reliable without depending on the `Loaded` event.
+	pub fn preload(&self, settings: &crate::config::SoundSettings) {
+		for event in SoundEvent::ALL {
+			// Resolve through the settings so the active pack and any per-event override agree
+			// with what will actually be played later.
+			if let Some(file) = settings.file_for(event)
+				&& let Some(path) = Self::resolve(&file)
+			{
+				self.ensure_slot(event, path, false);
+			}
+		}
+	}
+
+	/// Load just one event's sound, for auditioning without touching the other fourteen.
+	pub fn preload_one(&self, settings: &crate::config::SoundSettings, event: SoundEvent) {
+		let file = settings.file_for(event).or_else(|| Self::pack_file(&settings.pack, event)).unwrap_or_default();
+		if let Some(path) = Self::resolve(&file) {
+			self.ensure_slot(event, path, false);
+		}
+	}
+
+	/// Drop every cached control, tearing down the windows behind them.
+	///
+	/// `MediaCtrl` is a `Copy` handle with no `Drop`, so the child windows have to be destroyed
+	/// explicitly or each rebuild would orphan one.
+	pub fn invalidate_all(&self) {
+		for (_, slot) in self.slots.borrow_mut().drain() {
+			slot.ctrl.destroy();
+		}
+	}
+
+	/// Create and load the control for `event`, replacing any control holding a different file.
+	///
+	/// `play_when_ready` starts playback as soon as the file is loaded, for the case where a sound
+	/// is played before it was ever preloaded.
+	fn ensure_slot(&self, event: SoundEvent, path: PathBuf, play_when_ready: bool) {
+		let mut slots = self.slots.borrow_mut();
+		if let Some(slot) = slots.get_mut(&event) {
+			// Already holding this exact file; nothing to do.
+			if slot.path == path {
+				if play_when_ready {
+					slot.ctrl.stop();
+					slot.ctrl.play();
+				}
+				return;
+			}
+			// Point the existing control at the new file rather than building another one.
+			// Creating a MediaCtrl is far more expensive than loading into one, and switching
+			// packs changes every event at once, so rebuilding here made the dialog crawl.
+			if slot.ctrl.load(&path.to_string_lossy()) {
+				slot.path = path;
+				slot.ctrl.set_volume(self.volume.get());
+				if play_when_ready {
+					slot.ctrl.play();
+				}
+				return;
+			}
+			// The control refused the new file, so fall through and build a fresh one.
+			if let Some(stale) = slots.remove(&event) {
+				stale.ctrl.destroy();
+			}
+		}
+		let ctrl = MediaCtrl::builder(&self.parent).with_size(Size::new(0, 0)).build();
+		let volume = self.volume.clone();
+		let pending_play = Rc::new(Cell::new(play_when_ready));
+		let ctrl_for_event = ctrl;
+		{
+			let pending_play = pending_play.clone();
+			let volume = volume.clone();
+			// Only a safety net. The backend may never send this, which is why playback does not
+			// depend on it.
+			ctrl.on_loaded(move |_| {
+				ctrl_for_event.set_volume(volume.get());
+				if pending_play.replace(false) {
+					ctrl_for_event.stop();
+					ctrl_for_event.play();
+				}
+			});
+		}
+		if !ctrl.load(&path.to_string_lossy()) {
+			ctrl.destroy();
+			return;
+		}
+		// Volume only takes effect once a file is loaded, so apply it now rather than at creation.
+		ctrl.set_volume(volume.get());
+		if play_when_ready && pending_play.replace(false) {
+			ctrl.play();
+		}
+		slots.insert(event, Slot { ctrl, path });
+	}
+
+	/// Play `event` using `file`, which may be a bare name or an absolute path.
+	///
+	/// Does nothing if the file cannot be found, so a missing or deleted custom sound degrades to
+	/// silence rather than an error dialog on every notification.
+	pub fn play(&self, event: SoundEvent, file: &str) {
+		let Some(path) = Self::resolve(file) else {
+			return;
+		};
+		let needs_build = {
+			let slots = self.slots.borrow();
+			slots.get(&event).is_none_or(|slot| slot.path != path)
+		};
+		if needs_build {
+			// Builds and starts it; nothing further to do here.
+			self.ensure_slot(event, path, true);
+			return;
+		}
+		let slots = self.slots.borrow();
+		if let Some(slot) = slots.get(&event) {
+			slot.ctrl.set_volume(self.volume.get());
+			slot.ctrl.stop();
+			slot.ctrl.play();
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::SoundEvent;
+
+	fn sounds_dir() -> std::path::PathBuf {
+		std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("sounds")
+	}
+
+	fn missing_events(pack_dir: &std::path::Path) -> Vec<String> {
+		SoundEvent::ALL.iter().map(|event| event.default_file()).filter(|file| !pack_dir.join(file).exists()).collect()
+	}
+
+	/// Every event falls back to this one file, so losing it would silence the feature outright for
+	/// anyone who has not chosen sounds of their own.
+	#[test]
+	fn fallback_sound_is_shipped() {
+		let path = sounds_dir().join(super::SoundPlayer::FALLBACK_FILE);
+		assert!(path.exists(), "the fallback sound is missing from {}", path.display());
+	}
+
+	/// A pack that is present must be complete, so switching to it never silently borrows a sound
+	/// from somewhere else.
+	///
+	/// Fedra itself ships none, and `sounds/packs` is ignored by git precisely so a contributor's
+	/// own pack stays out of the repository. This therefore checks whatever is on the machine
+	/// running it, which is the useful thing to check either way.
+	#[test]
+	fn any_pack_present_is_complete() {
+		let Ok(entries) = std::fs::read_dir(sounds_dir().join("packs")) else { return };
+		for entry in entries.flatten().filter(|entry| entry.path().is_dir()) {
+			let missing = missing_events(&entry.path());
+			assert!(missing.is_empty(), "pack {:?} is missing {missing:?}", entry.file_name());
+		}
+	}
+
+	/// Config keys are persisted, so duplicates would silently merge two events into one setting.
+	#[test]
+	fn event_keys_are_unique() {
+		let mut keys: Vec<_> = SoundEvent::ALL.iter().map(|event| event.key()).collect();
+		let before = keys.len();
+		keys.sort_unstable();
+		keys.dedup();
+		assert_eq!(keys.len(), before, "duplicate SoundEvent keys");
+	}
+}

--- a/src/ui/commands.rs
+++ b/src/ui/commands.rs
@@ -37,7 +37,9 @@ use crate::{
 /// Commands that can be triggered by UI events.
 pub enum UiCommand {
 	NewPost,
-	Reply { reply_all: bool },
+	Reply {
+		reply_all: bool,
+	},
 	Quote,
 	DeletePost,
 	EditPost,
@@ -57,6 +59,8 @@ pub enum UiCommand {
 	TimelineSelectionChanged(usize),
 	TimelineEntrySelectionChanged(usize),
 	ShowOptions,
+	/// Load the current sound pack once the options dialog has already closed.
+	ReloadSounds,
 	CustomizeShortcuts,
 	ManageAccounts,
 	SwitchAccount(String),
@@ -93,7 +97,10 @@ pub enum UiCommand {
 	ToggleWindowVisibility,
 	SetQuickActionKeysEnabled(bool),
 	SwitchTimelineByIndex(usize),
-	OAuthResult { result: Result<auth::OAuthResult, String>, instance_url: Url },
+	OAuthResult {
+		result: Result<auth::OAuthResult, String>,
+		instance_url: Url,
+	},
 	CancelAuth,
 	EditProfile,
 	ViewHelp,
@@ -164,6 +171,7 @@ pub fn handle_ui_command(cmd: UiCommand, ctx: &mut UiCommandContext<'_>) {
 		UiCommand::TimelineEntrySelectionChanged(index) => timeline::timeline_entry_selection_changed(ctx, index),
 		UiCommand::ShowOptions => settings::show_options(ctx),
 		UiCommand::CustomizeShortcuts => settings::customize_shortcuts(ctx),
+		UiCommand::ReloadSounds => settings::reload_sounds(ctx),
 		UiCommand::ManageAccounts => account::manage_accounts(ctx),
 		UiCommand::SwitchAccount(id) => account::switch_account(ctx, id),
 		UiCommand::SwitchNextAccount => account::switch_next_account(ctx),

--- a/src/ui/commands/settings.rs
+++ b/src/ui/commands/settings.rs
@@ -38,6 +38,7 @@ pub(super) fn show_options(ctx: &mut UiCommandContext<'_>) {
 			default_timelines: state.config.default_timelines.clone(),
 			restore_open_timelines: state.config.restore_open_timelines,
 			notification_preference: state.config.notification_preference,
+			sounds: state.config.sounds.clone(),
 			hotkey: state.config.hotkey.clone(),
 			shortcuts: state.config.shortcuts.clone(),
 			templates: state.config.templates.clone(),
@@ -63,6 +64,7 @@ pub(super) fn show_options(ctx: &mut UiCommandContext<'_>) {
 			default_timelines,
 			restore_open_timelines,
 			notification_preference,
+			sounds,
 			hotkey,
 			shortcuts,
 			templates,
@@ -95,6 +97,17 @@ pub(super) fn show_options(ctx: &mut UiCommandContext<'_>) {
 		state.config.default_timelines = default_timelines;
 		state.config.restore_open_timelines = restore_open_timelines;
 		state.config.notification_preference = notification_preference;
+		// Rebuild the cached media controls so changed files and volume take effect immediately.
+		let sounds_changed = state.config.sounds != sounds;
+		state.config.sounds = sounds;
+		if let Some(player) = &state.sound_player {
+			player.set_volume(state.config.sounds.volume);
+		}
+		if sounds_changed {
+			// Loading a whole pack takes long enough to be heard as a stall, so let the dialog
+			// finish closing first and do it on the next pass through the command queue.
+			let _ = ui_tx.send(UiCommand::ReloadSounds);
+		}
 		state.config.hotkey = hotkey;
 		state.config.shortcuts = shortcuts;
 		*shortcuts_cell.borrow_mut() = state.config.shortcuts.clone();
@@ -139,6 +152,17 @@ pub(super) fn show_options(ctx: &mut UiCommandContext<'_>) {
 				);
 			}
 		}
+	}
+}
+
+/// Reload every sound for the active pack.
+///
+/// Deferred out of the options dialog so closing it stays responsive; by the time this runs the
+/// main window is back, and no notification can arrive in between.
+pub(super) fn reload_sounds(ctx: &mut UiCommandContext<'_>) {
+	let state = &mut *ctx.state;
+	if let Some(player) = &state.sound_player {
+		player.preload(&state.config.sounds);
 	}
 }
 

--- a/src/ui/dialogs/options.rs
+++ b/src/ui/dialogs/options.rs
@@ -155,6 +155,7 @@ pub struct OptionsDialogInput {
 	pub default_timelines: Vec<DefaultTimeline>,
 	pub restore_open_timelines: bool,
 	pub notification_preference: NotificationPreference,
+	pub sounds: crate::config::SoundSettings,
 	pub hotkey: HotkeyConfig,
 	pub shortcuts: crate::config::ShortcutsConfig,
 	pub templates: PostTemplates,
@@ -181,6 +182,7 @@ pub struct OptionsDialogResult {
 	pub default_timelines: Vec<DefaultTimeline>,
 	pub restore_open_timelines: bool,
 	pub notification_preference: NotificationPreference,
+	pub sounds: crate::config::SoundSettings,
 	pub hotkey: HotkeyConfig,
 	pub shortcuts: crate::config::ShortcutsConfig,
 	pub templates: PostTemplates,
@@ -209,6 +211,7 @@ pub fn prompt_for_options(frame: &Frame, input: OptionsDialogInput) -> Option<Op
 		default_timelines: default_timelines_val,
 		restore_open_timelines,
 		notification_preference,
+		sounds,
 		hotkey,
 		shortcuts,
 		templates,
@@ -251,8 +254,12 @@ pub fn prompt_for_options(frame: &Frame, input: OptionsDialogInput) -> Option<Op
 	channel_sizer.add(&channel_choice, 1, SizerFlag::Expand, 0);
 
 	let notification_label = StaticText::builder(&general_panel).with_label("Notifications:").build();
-	let notification_choices =
-		vec!["Classic Windows Notifications".to_string(), "Sound only".to_string(), "Disabled".to_string()];
+	let notification_choices = vec![
+		"Classic Windows Notifications".to_string(),
+		"Sound only".to_string(),
+		"Sound and notifications".to_string(),
+		"Disabled".to_string(),
+	];
 	let notification_choice = ComboBox::builder(&general_panel)
 		.with_choices(notification_choices)
 		.with_style(ComboBoxStyle::ReadOnly)
@@ -260,7 +267,8 @@ pub fn prompt_for_options(frame: &Frame, input: OptionsDialogInput) -> Option<Op
 	let notification_index = match notification_preference {
 		NotificationPreference::Classic => 0,
 		NotificationPreference::SoundOnly => 1,
-		NotificationPreference::Disabled => 2,
+		NotificationPreference::SoundAndClassic => 2,
+		NotificationPreference::Disabled => 3,
 	};
 	notification_choice.set_selection(notification_index);
 	let notification_sizer = BoxSizer::builder(Orientation::Horizontal).build();
@@ -577,6 +585,258 @@ pub fn prompt_for_options(frame: &Frame, input: OptionsDialogInput) -> Option<Op
 	filters_panel.set_sizer(filters_sizer, true);
 	notebook.add_page(&filters_panel, "Filters", false, None);
 
+	// ---- Sounds tab ---------------------------------------------------------
+	let sounds_panel = Panel::builder(&notebook).with_style(PanelStyle::TabTraversal).build();
+	let sounds_sizer = BoxSizer::builder(Orientation::Vertical).build();
+	let sounds_enabled_checkbox = CheckBox::builder(&sounds_panel).with_label("&Enable notification sounds").build();
+	sounds_enabled_checkbox.set_value(sounds.enabled);
+	sounds_sizer.add(&sounds_enabled_checkbox, 0, SizerFlag::All, 5);
+	let volume_label = StaticText::builder(&sounds_panel).with_label("&Volume:").build();
+	let volume_slider = Slider::builder(&sounds_panel).build();
+	volume_slider.set_range(0, 100);
+	volume_slider.set_value(i32::from(sounds.volume.min(100)));
+	let volume_sizer = BoxSizer::builder(Orientation::Horizontal).build();
+	volume_sizer.add(&volume_label, 0, SizerFlag::AlignCenterVertical | SizerFlag::Right, 8);
+	volume_sizer.add(&volume_slider, 1, SizerFlag::Expand, 0);
+	sounds_sizer.add_sizer(&volume_sizer, 0, SizerFlag::Expand | SizerFlag::All, 5);
+	let pack_label = StaticText::builder(&sounds_panel).with_label("Sound &pack:").build();
+	let pack_names = crate::sounds::SoundPlayer::list_packs();
+	let pack_choices: Vec<String> = pack_names
+		.iter()
+		.map(|pack| {
+			let covered = crate::sounds::SoundPlayer::pack_coverage(pack);
+			let total = crate::sounds::SoundEvent::ALL.len();
+			let display = crate::sounds::SoundPlayer::pack_display_name(pack);
+			// Say when a pack is partly filled in, since the missing events fall back elsewhere.
+			// Nothing is said for a pack providing none, which is what an untouched install looks
+			// like: every event on the shipped fallback, and no fault to report.
+			if covered == 0 || covered >= total { display } else { format!("{display} ({covered} of {total} sounds)") }
+		})
+		.collect();
+	let pack_choice =
+		ComboBox::builder(&sounds_panel).with_choices(pack_choices).with_style(ComboBoxStyle::ReadOnly).build();
+	let initial_pack = pack_names.iter().position(|pack| *pack == sounds.pack).unwrap_or(0);
+	pack_choice.set_selection(u32::try_from(initial_pack).unwrap_or(0));
+	let pack_sizer = BoxSizer::builder(Orientation::Horizontal).build();
+	pack_sizer.add(&pack_label, 0, SizerFlag::AlignCenterVertical | SizerFlag::Right, 8);
+	pack_sizer.add(&pack_choice, 1, SizerFlag::Expand, 0);
+	sounds_sizer.add_sizer(&pack_sizer, 0, SizerFlag::Expand | SizerFlag::All, 5);
+
+	let sounds_list_label =
+		StaticText::builder(&sounds_panel).with_label("So&unds (uncheck an event to silence just it):").build();
+	sounds_sizer.add(&sounds_list_label, 0, SizerFlag::Left | SizerFlag::Top, 5);
+	let sounds_list = CheckListBox::builder(&sounds_panel).build();
+	sounds_sizer.add(&sounds_list, 1, SizerFlag::Expand | SizerFlag::All, 5);
+
+	// Working copy of the settings, edited in place and read back when OK is pressed.
+	let sound_state = Rc::new(RefCell::new(sounds.clone()));
+	let pack_names = Rc::new(pack_names);
+	let refresh_sounds_list = {
+		let sound_state = sound_state.clone();
+		Rc::new(move || {
+			let selection = sounds_list.get_selection();
+			sounds_list.clear();
+			for event in crate::sounds::SoundEvent::ALL {
+				let state = sound_state.borrow();
+				let setting = state.for_event(event);
+				// An empty file means the pack supplies it; say so rather than showing a blank.
+				let shown = if setting.file.trim().is_empty() {
+					state
+						.file_for(event)
+						.or_else(|| crate::sounds::SoundPlayer::pack_file(&state.pack, event))
+						.map_or_else(
+							|| "no sound found".to_string(),
+							|file| {
+								let name = std::path::Path::new(&file)
+									.file_name()
+									.map_or_else(|| file.clone(), |n| n.to_string_lossy().into_owned());
+								format!("from pack, {name}")
+							},
+						)
+				} else {
+					let name = std::path::Path::new(&setting.file)
+						.file_name()
+						.map_or_else(|| setting.file.clone(), |n| n.to_string_lossy().into_owned());
+					if crate::sounds::SoundPlayer::resolve(&setting.file).is_some() {
+						format!("custom, {name}")
+					} else {
+						format!("custom, {name} (file missing)")
+					}
+				};
+				drop(state);
+				sounds_list.append(&format!("{}: {shown}", event.label()));
+			}
+			for (index, event) in crate::sounds::SoundEvent::ALL.iter().enumerate() {
+				let enabled = sound_state.borrow().for_event(*event).enabled;
+				if let Ok(index) = u32::try_from(index) {
+					sounds_list.check(index, enabled);
+				}
+			}
+			if let Some(selection) = selection {
+				sounds_list.set_selection(selection, true);
+			} else if sounds_list.get_count() > 0 {
+				sounds_list.set_selection(0, true);
+			}
+		})
+	};
+	refresh_sounds_list();
+
+	// Preview uses its own player so the dialog can audition sounds without touching app state.
+	let preview_player = Rc::new(crate::sounds::SoundPlayer::new(*frame));
+	preview_player.set_volume(sounds.volume);
+	// Only the first row is loaded up front; the rest load as the user moves through the list.
+	if let Some(first) = crate::sounds::SoundEvent::ALL.first() {
+		preview_player.preload_one(&sounds, *first);
+	}
+	let sound_buttons = BoxSizer::builder(Orientation::Horizontal).build();
+	let preview_button = Button::builder(&sounds_panel).with_label("&Play").build();
+	let change_button = Button::builder(&sounds_panel).with_label("&Change...").build();
+	let reset_button = Button::builder(&sounds_panel).with_label("&Reset").build();
+	let reset_all_button = Button::builder(&sounds_panel).with_label("Reset a&ll").build();
+	let folder_button = Button::builder(&sounds_panel).with_label("&Open sounds folder").build();
+	sound_buttons.add(&preview_button, 0, SizerFlag::All, 4);
+	sound_buttons.add(&change_button, 0, SizerFlag::All, 4);
+	sound_buttons.add(&reset_button, 0, SizerFlag::All, 4);
+	sound_buttons.add(&reset_all_button, 0, SizerFlag::All, 4);
+	sound_buttons.add(&folder_button, 0, SizerFlag::All, 4);
+	sounds_sizer.add_sizer(&sound_buttons, 0, SizerFlag::Expand | SizerFlag::All, 5);
+	sounds_panel.set_sizer(sounds_sizer, true);
+	notebook.add_page(&sounds_panel, "Sounds", false, None);
+
+	{
+		let sound_state = sound_state.clone();
+		let refresh = refresh_sounds_list.clone();
+		let preview_player = preview_player.clone();
+		let sounds_list_for_pack = sounds_list;
+		pack_choice.on_selection_changed(move |event| {
+			let Some(index) = event.get_selection().and_then(|index| usize::try_from(index).ok()) else { return };
+			let Some(pack) = pack_names.get(index) else { return };
+			let settings = {
+				let mut state = sound_state.borrow_mut();
+				state.pack.clone_from(pack);
+				state.clone()
+			};
+			// Load only what is about to be auditioned. Loading the whole pack here meant
+			// fifteen loads on every keystroke through the dropdown.
+			if let Some(index) = sounds_list_for_pack.get_selection()
+				&& let Some(selected) = crate::sounds::SoundEvent::ALL.get(index as usize).copied()
+			{
+				preview_player.preload_one(&settings, selected);
+			}
+			refresh();
+		});
+	}
+
+	{
+		let sound_state = sound_state.clone();
+		let preview_player = preview_player.clone();
+		sounds_list.on_selected(move |event| {
+			let Some(index) = event.get_selection() else { return };
+			let Some(selected) = crate::sounds::SoundEvent::ALL.get(index as usize).copied() else { return };
+			preview_player.preload_one(&sound_state.borrow(), selected);
+		});
+	}
+
+	// Keep the preview player in step with the slider so auditioning matches real playback.
+	{
+		let preview_player = preview_player.clone();
+		volume_slider.on_slider(move |event| {
+			let value = u8::try_from(event.get_value().clamp(0, 100)).unwrap_or(80);
+			preview_player.set_volume(value);
+		});
+	}
+	{
+		let sound_state = sound_state.clone();
+		sounds_list.on_toggled(move |event| {
+			let Some(index) = event.get_selection() else { return };
+			let Some(sound_event) = crate::sounds::SoundEvent::ALL.get(index as usize).copied() else { return };
+			let checked = sounds_list.is_checked(index);
+			let mut state = sound_state.borrow_mut();
+			let mut setting = state.for_event(sound_event);
+			setting.enabled = checked;
+			state.set_event(sound_event, setting);
+		});
+	}
+	{
+		let sound_state = sound_state.clone();
+		let preview_player = preview_player.clone();
+		preview_button.on_click(move |_| {
+			let Some(index) = sounds_list.get_selection() else { return };
+			let Some(event) = crate::sounds::SoundEvent::ALL.get(index as usize).copied() else { return };
+			let file = {
+				let state = sound_state.borrow();
+				let setting = state.for_event(event);
+				if setting.file.trim().is_empty() {
+					crate::sounds::SoundPlayer::pack_file(&state.pack, event)
+				} else {
+					Some(setting.file)
+				}
+			};
+			// Auditioning ignores the enabled flag so a silenced event can still be heard here.
+			// `play` rebuilds the control by itself when the chosen file has changed.
+			if let Some(file) = file {
+				preview_player.play(event, &file);
+			}
+		});
+	}
+	{
+		let sound_state = sound_state.clone();
+		let refresh = refresh_sounds_list.clone();
+		let preview_player = preview_player.clone();
+		change_button.on_click(move |_| {
+			let Some(index) = sounds_list.get_selection() else { return };
+			let Some(event) = crate::sounds::SoundEvent::ALL.get(index as usize).copied() else { return };
+			let file_dialog = FileDialog::builder(&sounds_panel)
+				.with_message(&format!("Choose a sound for: {}", event.label()))
+				.with_wildcard("Sound files|*.mp3;*.wav;*.ogg;*.flac;*.m4a;*.aac;*.opus|All files|*.*")
+				.with_style(FileDialogStyle::Open | FileDialogStyle::FileMustExist)
+				.build();
+			if file_dialog.show_modal() == ID_OK
+				&& let Some(path) = file_dialog.get_path()
+			{
+				let mut state = sound_state.borrow_mut();
+				let mut setting = state.for_event(event);
+				setting.file = path;
+				// Picking a file implies wanting to hear it.
+				setting.enabled = true;
+				state.set_event(event, setting);
+				let settings = state.clone();
+				drop(state);
+				// Load the new file now so pressing Play straight away is not silent.
+				preview_player.preload_one(&settings, event);
+				refresh();
+			}
+		});
+	}
+	{
+		let sound_state = sound_state.clone();
+		let refresh = refresh_sounds_list.clone();
+		reset_button.on_click(move |_| {
+			let Some(index) = sounds_list.get_selection() else { return };
+			let Some(event) = crate::sounds::SoundEvent::ALL.get(index as usize).copied() else { return };
+			let mut state = sound_state.borrow_mut();
+			let enabled = state.for_event(event).enabled;
+			// Clearing the file hands this event back to the active pack.
+			state.set_event(event, crate::config::EventSound { enabled, file: String::new() });
+			drop(state);
+			refresh();
+		});
+	}
+	{
+		let sound_state = sound_state.clone();
+		let refresh = refresh_sounds_list;
+		reset_all_button.on_click(move |_| {
+			sound_state.borrow_mut().events.clear();
+			refresh();
+		});
+	}
+	folder_button.on_click(move |_| {
+		// Seed it first; an empty folder tells the user nothing about what they can replace.
+		let dir = crate::sounds::SoundPlayer::seed_user_dir();
+		#[cfg(target_os = "windows")]
+		let _ = std::process::Command::new("explorer").arg(&dir).spawn();
+	});
+
 	let filters_state = Rc::new(RefCell::new(filters));
 	let current_filter_key = Rc::new(RefCell::new("Home".to_string()));
 	{
@@ -728,6 +988,9 @@ pub fn prompt_for_options(frame: &Frame, input: OptionsDialogInput) -> Option<Op
 	dialog.set_escape_id(ID_CANCEL);
 	dialog.centre();
 	let result = dialog.show_modal();
+	// The preview controls hang off the frame rather than the dialog, so they outlive it unless
+	// they are torn down here.
+	preview_player.invalidate_all();
 	if result != ID_OK {
 		return None;
 	}
@@ -755,7 +1018,8 @@ pub fn prompt_for_options(frame: &Frame, input: OptionsDialogInput) -> Option<Op
 	let new_notification_preference = match notification_choice.get_selection() {
 		Some(0) => crate::config::NotificationPreference::Classic,
 		Some(1) => crate::config::NotificationPreference::SoundOnly,
-		Some(2) => crate::config::NotificationPreference::Disabled,
+		Some(2) => crate::config::NotificationPreference::SoundAndClassic,
+		Some(3) => crate::config::NotificationPreference::Disabled,
 		_ => notification_preference,
 	};
 	let new_update_channel = match channel_choice.get_selection() {
@@ -812,6 +1076,12 @@ pub fn prompt_for_options(frame: &Frame, input: OptionsDialogInput) -> Option<Op
 		preserve_thread_order: thread_order_checkbox.get_value(),
 		default_timelines: current_defaults.borrow().clone(),
 		notification_preference: new_notification_preference,
+		sounds: {
+			let mut settings = sound_state.borrow().clone();
+			settings.enabled = sounds_enabled_checkbox.get_value();
+			settings.volume = u8::try_from(volume_slider.get_value().clamp(0, 100)).unwrap_or(80);
+			settings
+		},
 		hotkey: current_hotkey.borrow().clone(),
 		shortcuts: current_shortcuts.borrow().clone(),
 		templates: new_templates,


### PR DESCRIPTION
I use Fedra every day, and wanted to tell events apart by ear rather than waiting for the screen reader to reach them. This adds a sound per event.

### One thing first

At the end of August I forked Fedra, renamed it, and released it with these sounds in it. The MIT licence permitted that, but renaming and redistributing someone else's work without asking was not the right call. I pulled it from distribution the next day and made the repository private. This is that same work, offered back here instead, which is where it should have gone in the first place. Entirely fair if that affects how you want to handle this PR.

### The change

It is a fair-sized change, so please treat it as a proposal rather than a finished thing. Happy to split it up, rework any of it, or drop it if it is not a direction you want the app to go.

### What it does

Fedra plays `sounds/boop.mp3` for every notification. This keeps that as the fallback and lets each event take a sound of its own instead, so an install nobody has touched sounds exactly as it does today.

Fifteen events are covered: mentions, direct messages, new home-timeline posts, follows, follow requests, favorites, boosts, bookmarks, pins, ended polls, poll votes, edited posts, sent posts, deleted posts, and failures. A direct message is told apart from an ordinary mention by the visibility of the post carrying it.

Sounds are tied to actions, not only to things arriving. Every action completes as a `NetworkResponse`, so those are mapped to sounds in one place rather than per handler, which stops a new action from silently missing its sound. Both directions of a pair share a sound: favoriting a post and having one of yours favorited sound the same, as do boosting, following and editing. Blocking, muting and hiding boosts get no sound at all, since borrowing the follow sound for them would be misleading.

Action sounds are deliberately not gated on the notification preference. That setting is about how arriving notifications are presented, and a sound confirming something the user just did should not depend on it. Arriving sounds do follow it, and a `Sound and notifications` mode is added, since a sound and a Windows notification were previously mutually exclusive.

A Sounds tab in Options carries the master switch, the volume, a pack chooser, and one row per event, with Play, Change, Reset, Reset all, and Open sounds folder.

### No audio is bundled, deliberately

Nothing new ships in the repository. Every event falls back to the existing `boop.mp3`, and anything beyond that is a file the user supplies: one event at a time, or a whole pack, which is a folder of files named after the events they play for, under `packs/` in the configuration folder.

Two reasons for that. A fixed set of sounds imposes one person's taste on everybody who installs the app. And audio carries redistribution terms of its own, which I did not think it was right to hand you along with the code. `sounds/packs` is gitignored so a contributor's own pack stays out of the repository.

The trade-off is that the feature does nothing audible until someone supplies sounds, beyond the fallback it already had. If you would rather it shipped with a default set, say so and I will source something clearly licensed and add it.

### Notes from making it work

- `MediaCtrl::load` is asynchronous and the backend does not reliably deliver a `Loaded` event. An earlier version waited for one before playing, and no sound ever played. Controls are preloaded instead, and `play()` is an unconditional stop-then-play, which is what the original single-sound code did.
- `MediaCtrl::set_volume` returns false while no media is loaded, so setting the volume right after construction was a silent no-op and the slider did nothing. Volume is applied after load and again on each play.
- Creating a `MediaCtrl` is far more expensive than loading a file into one, so changing a sound reuses the existing control rather than tearing it down. The options dialog loads one sound at a time rather than a whole pack. Switching packs went from roughly 190 ms to about 5 ms.

### Testing

- `cargo test` passes, with new tests covering the fallback file and pack completeness.
- `cargo +nightly fmt --check` is clean, matching what `ci.yml` runs.
- Clippy reports nothing on this change. My local toolchain is newer than the one CI pins and flags a good deal across the existing tree, so I checked its findings against the changed lines rather than against the total.
- Playback was verified during development by instrumenting a build: after `play()` the control reports `Playing` at the configured volume across three consecutive 250 ms samples, and returns to `Stopped` once the sound's duration has elapsed.

`doc/readme.md` gains a Sounds Tab section, a Sound Packs section, and a changelog entry.

One unrelated thing I noticed: `ci.yml` triggers on `master`, but the default branch is `main`, so CI may not run on this PR at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
