### PR TITLE
Autocomplete for Mentions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ accesskit = "0.24.1"
 
 [target.'cfg(windows)'.dependencies]
 accesskit_windows = "0.34.0"
-windows = { version = "0.62.2", features = ["Win32_Foundation", "Win32_Graphics_Gdi", "Win32_System_Com", "Win32_System_Ole", "Win32_System_Threading", "Win32_System_Variant", "Win32_UI_Accessibility", "Win32_UI_Controls", "Win32_UI_Input", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging", "Win32_UI_Shell"] }
+windows = { version = "0.62.2", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_Graphics_Gdi", "Win32_System_Com", "Win32_System_Ole", "Win32_System_Threading", "Win32_System_Variant", "Win32_UI_Accessibility", "Win32_UI_Controls", "Win32_UI_Input", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging", "Win32_UI_Shell"] }
 
 [build-dependencies]
 embed-manifest = "1.5.0"

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -101,6 +101,14 @@ The dialog offers:
 
 If `Use enter to send posts` is enabled, `Enter` posts from the content field; otherwise use the Post button.
 
+## Autocomplete users
+
+Click the **Autocomplete...** button below the post body, or press `Alt+A` to insert or complete a mention where your cursor resides. This works in new posts, replies, quotes, edits, and recovered drafts. The user picker searches your account's following, followers, and people you have successfully favorited, boosted, replied to, quoted, or followed in Fedra. Available entries can be used while the cache builds or refreshes in the background.
+
+Use `Alt+F` for the Filter field and `Alt+U` for the Users list. Type the beginning of a display name or username, optionally including `@` and part of its instance domain; matching is case insensitive`. Clear the filter to show everyone. Use the arrow keys to select a user and `Enter` to insert their full address. `Escape` or Cancel leaves your text and selection unchanged.
+
+Autocomplete replaces selected text or the mention touching your cursor. Inside an ordinary word, it inserts after that word. The cache is separate for each signed-in account and refreshes daily; successful unfollows and blocks remove users from it.
+
 ## Options
 Open options with `Ctrl+,`.
 

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -125,8 +125,13 @@ pub fn switch_to_account(
 	}
 
 	state.network_handle = None;
+	state.autocomplete.pause();
+	state.current_user_id = None;
 	let active_id =
 		state.config.active_account_id.clone().or_else(|| state.config.accounts.first().map(|a| a.id.clone()));
+	if let Some(id) = &active_id {
+		state.autocomplete.select(id.clone());
+	}
 
 	if let Some(id) = &active_id {
 		if let Some(mgr) = state.account_timelines.remove(id) {
@@ -146,7 +151,9 @@ pub fn switch_to_account(
 	};
 	state.streaming_url = Some(url.clone());
 	state.access_token = Some(token.clone());
-	state.network_handle = network::start_network(url.clone(), token.clone(), state.ui_waker.clone()).ok();
+	if let Some(session) = state.autocomplete_session() {
+		state.network_handle = network::start_network(url.clone(), token.clone(), state.ui_waker.clone(), session).ok();
+	}
 	if let Ok(client) = MastodonClient::new(url) {
 		state.client = Some(client.clone());
 		if let Ok(info) = client.get_instance_info() {
@@ -176,6 +183,13 @@ pub fn switch_to_account(
 		} else if let Some(active) = state.active_account() {
 			state.current_user_id = active.user_id.clone();
 		}
+	}
+
+	if let Some(account) = state.active_account()
+		&& let Some(user_id) = &account.user_id
+		&& let Some(client) = &state.client
+	{
+		state.autocomplete.activate(account.id.clone(), client.base_url().clone(), token, user_id.clone());
 	}
 
 	if state.timeline_manager.len() == 0 {

--- a/src/autocomplete/mod.rs
+++ b/src/autocomplete/mod.rs
@@ -1,0 +1,911 @@
+//! Account-bound, incrementally published mention cache. Only the coordinator mutates cache data.
+pub mod rate;
+mod storage;
+#[cfg(test)]
+mod tests;
+pub mod text;
+mod timing;
+
+use std::{
+	collections::{HashMap, HashSet},
+	ops::Range,
+	path::PathBuf,
+	sync::{
+		Arc, Mutex,
+		mpsc::{self, Sender},
+	},
+	thread,
+	time::{Duration, Instant},
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+	mastodon::{Account, MastodonClient, Relationship},
+	ui_wake::UiWaker,
+};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Entry {
+	pub id: String,
+	pub address: String,
+	pub display_name: String,
+	pub revision: u64,
+	// Only used while merging API results; unavailable entries are never stored.
+	#[serde(skip)]
+	pub unavailable: bool,
+}
+
+impl Entry {
+	fn valid(&self) -> bool {
+		let parts: Vec<_> = self.address.split('@').collect();
+		!self.id.is_empty()
+			&& parts.len() == 3
+			&& parts[0].is_empty()
+			&& !parts[1].is_empty()
+			&& !parts[2].is_empty()
+			&& !self.address.chars().any(char::is_whitespace)
+	}
+	pub fn from_account(account: &Account, server: &url::Url) -> Self {
+		let acct = account.acct.trim_start_matches('@');
+		let address = if acct.contains('@') {
+			format!("@{acct}")
+		} else {
+			format!("@{acct}@{}", server.host_str().unwrap_or_default())
+		};
+		Self {
+			id: account.id.clone(),
+			address,
+			display_name: account.display_name.clone(),
+			revision: 0,
+			unavailable: account.moved.is_some() || account.suspended == Some(true),
+		}
+	}
+	pub fn label(&self) -> String {
+		if self.display_name.is_empty() {
+			self.address.clone()
+		} else {
+			format!("{} ({})", self.display_name, self.address)
+		}
+	}
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct Source {
+	next: Option<String>,
+	done: bool,
+	seen: HashSet<String>,
+	#[serde(skip)]
+	paused: bool,
+	#[serde(skip)]
+	attempt: u32,
+	#[serde(skip)]
+	retry: Option<Instant>,
+	#[serde(skip)]
+	error: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct AccountCache {
+	entries: HashMap<String, Entry>,
+	unfollowed: HashSet<String>,
+	blocked: HashSet<String>,
+	#[serde(default)]
+	unavailable: HashSet<String>,
+	target_revisions: HashMap<String, u64>,
+	sources: [Source; 2],
+	following: HashSet<String>,
+	scanning_following: HashSet<String>,
+	#[serde(default)]
+	scan_revision: u64,
+	confirm: Vec<String>,
+	last_complete: Option<i64>,
+	#[serde(default)]
+	build_timing: Option<timing::BuildTiming>,
+	revision: u64,
+}
+
+impl AccountCache {
+	fn valid(&self) -> bool {
+		self.revision < u64::MAX / 2
+			&& self.scan_revision <= self.revision
+			&& self.target_revisions.values().all(|r| *r <= self.revision)
+			&& self.entries.iter().all(|(id, e)| {
+				id == &e.id
+					&& e.valid() && e.revision <= self.revision
+					&& !self.blocked.contains(id)
+					&& !self.unfollowed.contains(id)
+					&& !self.unavailable.contains(id)
+			})
+	}
+	fn merge(&mut self, mut entry: Entry, issued: u64, interaction: bool) {
+		if entry.id.is_empty() || (!interaction && self.target_revisions.get(&entry.id).is_some_and(|r| *r > issued)) {
+			return;
+		}
+		if entry.unavailable {
+			self.entries.remove(&entry.id);
+			self.target_revisions.insert(entry.id.clone(), self.revision);
+			self.unavailable.insert(entry.id);
+			return;
+		}
+		if !entry.valid() || self.blocked.contains(&entry.id) {
+			return;
+		}
+		// Reply/quote authors can be old snapshots. Only a fresh page clears this exclusion.
+		if interaction && self.unavailable.contains(&entry.id) {
+			return;
+		}
+		self.unavailable.remove(&entry.id);
+		if interaction {
+			self.unfollowed.remove(&entry.id);
+		}
+		if self.unfollowed.contains(&entry.id) {
+			return;
+		}
+		entry.revision = self.revision;
+		self.target_revisions.insert(entry.id.clone(), self.revision);
+		self.entries.insert(entry.id.clone(), entry);
+	}
+	fn relationship(&mut self, id: &str, action: Change) {
+		self.target_revisions.insert(id.to_owned(), self.revision);
+		match action {
+			Change::Unfollow => {
+				self.unfollowed.insert(id.to_owned());
+				self.entries.remove(id);
+				self.following.remove(id);
+				self.scanning_following.remove(id);
+			}
+			Change::Block => {
+				self.blocked.insert(id.to_owned());
+				self.entries.remove(id);
+			}
+			Change::Unblock => {
+				self.blocked.remove(id);
+			}
+		}
+	}
+	fn snapshot(&self, persistence_error: Option<String>) -> Snapshot {
+		let mut entries: Vec<_> = self.entries.values().cloned().map(|e| (e.address.to_lowercase(), e)).collect();
+		entries.sort_unstable_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.id.cmp(&b.1.id)));
+		let mut display_names: Vec<_> = entries
+			.iter()
+			.enumerate()
+			.filter(|(_, (_, entry))| !entry.display_name.trim().is_empty())
+			.map(|(index, (_, entry))| (entry.display_name.trim().to_lowercase(), index))
+			.collect();
+		display_names.sort_unstable();
+		let availability = if !entries.is_empty() {
+			if self.sources.iter().all(|s| s.done) && self.confirm.is_empty() {
+				Availability::Usable
+			} else {
+				Availability::UsablePartial
+			}
+		} else if self.last_complete.is_some() {
+			Availability::CompletedEmpty
+		} else if let Some(error) = self.sources.iter().find_map(|s| s.error.clone()) {
+			Availability::Unavailable(error)
+		} else {
+			Availability::Building
+		};
+		Snapshot { entries, display_names, revision: self.revision, availability, persistence_error }
+	}
+}
+
+#[derive(Clone, Debug)]
+pub enum Availability {
+	Loading,
+	Building,
+	Usable,
+	UsablePartial,
+	CompletedEmpty,
+	Unavailable(String),
+}
+
+#[derive(Debug)]
+pub struct Snapshot {
+	pub entries: Vec<(String, Entry)>,
+	display_names: Vec<(String, usize)>,
+	pub revision: u64,
+	pub availability: Availability,
+	pub persistence_error: Option<String>,
+}
+
+pub enum Matches {
+	Range(Range<usize>),
+	Indices(Vec<usize>),
+}
+
+impl Matches {
+	pub fn len(&self) -> usize {
+		match self {
+			Self::Range(range) => range.len(),
+			Self::Indices(indices) => indices.len(),
+		}
+	}
+	pub fn get(&self, row: usize) -> Option<usize> {
+		match self {
+			Self::Range(range) => (row < range.len()).then(|| range.start + row),
+			Self::Indices(indices) => indices.get(row).copied(),
+		}
+	}
+}
+
+impl Snapshot {
+	pub fn matching(&self, query: &str) -> Matches {
+		let query = query.trim().to_lowercase();
+		let name_prefix = query.strip_prefix('@').unwrap_or(&query);
+		if name_prefix.is_empty() {
+			return Matches::Range(0..self.entries.len());
+		}
+		let prefix = format!("@{name_prefix}");
+		let start = self.entries.partition_point(|(key, _)| key < &prefix);
+		let end = start + self.entries[start..].partition_point(|(key, _)| key.starts_with(&prefix));
+		let name_start = self.display_names.partition_point(|(key, _)| key.as_str() < name_prefix);
+		let name_end =
+			name_start + self.display_names[name_start..].partition_point(|(key, _)| key.starts_with(name_prefix));
+		if name_start == name_end {
+			return Matches::Range(start..end);
+		}
+		// Store row indices only; both indexes refer to the same immutable entries.
+		let mut indices: Vec<_> =
+			(start..end).chain(self.display_names[name_start..name_end].iter().map(|(_, index)| *index)).collect();
+		indices.sort_unstable();
+		indices.dedup();
+		Matches::Indices(indices)
+	}
+}
+
+#[derive(Clone, Copy)]
+pub enum Change {
+	Unfollow,
+	Block,
+	Unblock,
+}
+
+#[derive(Default)]
+struct Published {
+	snapshots: HashMap<String, Arc<Snapshot>>,
+	active: Option<String>,
+	removed: HashSet<String>,
+	shutdown: Option<Result<(), String>>,
+}
+
+#[derive(Clone)]
+pub struct Service {
+	tx: Sender<Command>,
+	published: Arc<Mutex<Published>>,
+}
+
+impl std::fmt::Debug for Service {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.write_str("AutocompleteService")
+	}
+}
+
+#[derive(Clone, Debug)]
+pub struct Session {
+	pub service: Service,
+	pub account: String,
+}
+
+impl Session {
+	pub fn snapshot(&self) -> Arc<Snapshot> {
+		self.service.published.lock().unwrap().snapshots.get(&self.account).cloned().unwrap_or_else(|| {
+			Arc::new(Snapshot {
+				entries: Vec::new(),
+				display_names: Vec::new(),
+				revision: 0,
+				availability: Availability::Loading,
+				persistence_error: None,
+			})
+		})
+	}
+	pub fn eligible(&self) -> bool {
+		let published = self.service.published.lock().unwrap();
+		published.active.as_ref() == Some(&self.account) && !published.removed.contains(&self.account)
+	}
+	pub fn interaction(&self, entry: Entry) {
+		let _ = self.service.tx.send(Command::Interaction(self.account.clone(), entry, false));
+	}
+	pub fn follow(&self, entry: Entry) {
+		let _ = self.service.tx.send(Command::Interaction(self.account.clone(), entry, true));
+	}
+	pub fn relationship(&self, id: String, change: Change) {
+		let _ = self.service.tx.send(Command::Relationship(self.account.clone(), id, change));
+	}
+	pub fn observed_relationships(&self, relationships: Vec<Relationship>, revision: u64) {
+		let _ = self.service.tx.send(Command::ObservedRelationships(self.account.clone(), relationships, revision));
+	}
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct Credentials {
+	base: url::Url,
+	token: String,
+	user_id: String,
+}
+enum Command {
+	Select(String),
+	Activate(String, Credentials),
+	Pause,
+	Remove(String),
+	Interaction(String, Entry, bool),
+	Relationship(String, String, Change),
+	ObservedRelationships(String, Vec<Relationship>, u64),
+	Fetched(Job, Result<Fetched, String>, Option<u16>),
+	RequestStarted(String, u64),
+	Saved(u64, Result<bool, String>),
+	LogFlushed(Result<(), String>),
+	Shutdown,
+}
+
+enum DiskCommand {
+	Save(storage::FileData, u64, u64),
+	Log(String),
+	FlushLog,
+}
+
+#[derive(Clone)]
+struct Job {
+	owner: String,
+	generation: u64,
+	revision: u64,
+	source: usize,
+	next: Option<String>,
+	confirm: Vec<String>,
+	credentials: Credentials,
+}
+enum Fetched {
+	Page(Vec<Entry>, Option<String>),
+	Relationships(Vec<Relationship>),
+}
+
+impl Service {
+	#[cfg(test)]
+	pub(crate) fn select_for_ui_test(&self, id: &str) {
+		self.published.lock().unwrap().active = Some(id.into());
+	}
+	pub fn start(path: PathBuf, configured: HashSet<String>, waker: UiWaker) -> Self {
+		let (tx, rx) = mpsc::channel();
+		let published = Arc::new(Mutex::new(Published::default()));
+		let service = Self { tx, published };
+		let worker = service.clone();
+		thread::spawn(move || Coordinator::new(path, configured, worker, waker).run(&rx));
+		service
+	}
+	pub fn session(&self, account: String) -> Session {
+		Session { service: self.clone(), account }
+	}
+	pub fn select(&self, account: String) {
+		self.published.lock().unwrap().active = Some(account.clone());
+		let _ = self.tx.send(Command::Select(account));
+	}
+	pub fn activate(&self, account: String, base: url::Url, token: String, user_id: String) {
+		self.published.lock().unwrap().active = Some(account.clone());
+		let _ = self.tx.send(Command::Activate(account, Credentials { base, token, user_id }));
+	}
+	pub fn pause(&self) {
+		self.published.lock().unwrap().active = None;
+		let _ = self.tx.send(Command::Pause);
+	}
+	pub fn remove(&self, account: String) {
+		let mut published = self.published.lock().unwrap();
+		published.removed.insert(account.clone());
+		published.snapshots.remove(&account);
+		drop(published);
+		let _ = self.tx.send(Command::Remove(account));
+	}
+	pub fn shutdown(&self) {
+		self.published.lock().unwrap().active = None;
+		let _ = self.tx.send(Command::Shutdown);
+	}
+	pub fn shutdown_result(&self) -> Option<Result<(), String>> {
+		self.published.lock().unwrap().shutdown.clone()
+	}
+}
+
+// Fetch, save, persistence availability and shutdown are independent state axes.
+#[allow(clippy::struct_excessive_bools)]
+struct Coordinator {
+	accounts: HashMap<String, AccountCache>,
+	credentials: HashMap<String, Credentials>,
+	generations: HashMap<String, u64>,
+	active: Option<String>,
+	service: Service,
+	waker: UiWaker,
+	gate: Arc<Mutex<u64>>,
+	fetch: Sender<Job>,
+	disk: Sender<DiskCommand>,
+	log_flushed: bool,
+	log_error: Option<String>,
+	in_flight: bool,
+	saving: bool,
+	revision: u64,
+	saved: u64,
+	next_fetch: Instant,
+	next_save: Instant,
+	save_attempt: u32,
+	persistence_error: Option<String>,
+	writable: bool,
+	closing: bool,
+	final_attempt: bool,
+}
+
+impl Coordinator {
+	fn new(path: PathBuf, configured: HashSet<String>, service: Service, waker: UiWaker) -> Self {
+		// Loading happens on this thread before any queued startup commands are applied.
+		let loaded = storage::load(&path, &configured);
+		let gate = Arc::new(Mutex::new(0));
+		let (disk, writes) = mpsc::channel::<DiskCommand>();
+		let disk_tx = service.tx.clone();
+		let disk_gate = gate.clone();
+		thread::spawn(move || {
+			let mut log_error = None;
+			while let Ok(command) = writes.recv() {
+				match command {
+					DiskCommand::Save(data, revision, epoch) => {
+						let result = storage::save(&path, &data, epoch, &disk_gate).map_err(|e| e.to_string());
+						let _ = disk_tx.send(Command::Saved(revision, result));
+					}
+					DiskCommand::Log(message) => {
+						if let Err(error) = storage::append_log(&path.with_file_name("autocomplete.log"), &message) {
+							log_error = Some(format!("Could not write autocomplete.log: {error}"));
+						}
+					}
+					DiskCommand::FlushLog => {
+						let _ = disk_tx.send(Command::LogFlushed(log_error.take().map_or(Ok(()), Err)));
+					}
+				}
+			}
+		});
+		let (fetch, jobs) = mpsc::channel::<Job>();
+		let fetch_tx = service.tx.clone();
+		thread::spawn(move || {
+			while let Ok(job) = jobs.recv() {
+				let result = fetch_job(&job, || {
+					let _ = fetch_tx.send(Command::RequestStarted(job.owner.clone(), job.generation));
+				});
+				let status = result.as_ref().err().and_then(|error| {
+					// Locally rejected checkpoints use the same restart path as server-rejected cursors.
+					if error.is::<crate::mastodon::InvalidAccountPagination>() {
+						Some(400)
+					} else {
+						error.downcast_ref::<reqwest::Error>().and_then(reqwest::Error::status).map(|s| s.as_u16())
+					}
+				});
+				let _ = fetch_tx.send(Command::Fetched(job, result.map_err(|e| e.to_string()), status));
+			}
+		});
+		let mut accounts = loaded.accounts;
+		for id in configured {
+			accounts.entry(id).or_default();
+		}
+		let revision = accounts.values().map(|a| a.revision).max().unwrap_or(0) + 1;
+		Self {
+			generations: accounts.keys().map(|id| (id.clone(), 1)).collect(),
+			accounts,
+			credentials: HashMap::new(),
+			active: None,
+			service,
+			waker,
+			gate,
+			fetch,
+			disk,
+			log_flushed: false,
+			log_error: None,
+			in_flight: false,
+			saving: false,
+			revision,
+			saved: 0,
+			next_fetch: Instant::now(),
+			next_save: Instant::now() + Duration::from_secs(2),
+			save_attempt: 0,
+			persistence_error: loaded.error,
+			writable: loaded.writable,
+			closing: false,
+			final_attempt: false,
+		}
+	}
+	fn publish(&self, id: &str) {
+		if let Some(account) = self.accounts.get(id) {
+			let snapshot = Arc::new(account.snapshot(self.persistence_error.clone()));
+			self.service.published.lock().unwrap().snapshots.insert(id.to_owned(), snapshot);
+		}
+		self.waker.wake();
+	}
+	fn changed(&mut self, id: &str) {
+		self.revision += 1;
+		if let Some(account) = self.accounts.get_mut(id) {
+			account.revision = self.revision;
+		}
+		self.publish(id);
+	}
+	fn run(&mut self, rx: &mpsc::Receiver<Command>) {
+		for id in self.accounts.keys() {
+			self.publish(id);
+		}
+		loop {
+			// All accepted messages ahead of Shutdown are processed before the save barrier.
+			let now = Instant::now();
+			if !self.closing {
+				self.schedule(
+					now,
+					chrono::Utc::now().timestamp(),
+					rate::FOREGROUND.load(std::sync::atomic::Ordering::SeqCst) > 0,
+				);
+			}
+			if !self.saving
+				&& self.writable
+				&& self.revision != self.saved
+				&& !(self.closing && self.final_attempt)
+				&& (self.closing || now >= self.next_save)
+			{
+				self.saving = true;
+				self.final_attempt = self.closing;
+				let data = storage::FileData { version: 1, accounts: self.accounts.clone() };
+				let _ = self.disk.send(DiskCommand::Save(data, self.revision, *self.gate.lock().unwrap()));
+			}
+			if self.closing
+				&& self.log_flushed
+				&& !self.saving
+				&& (!self.writable || self.revision == self.saved || self.final_attempt)
+			{
+				let result = self.persistence_error.clone().or_else(|| self.log_error.clone()).map_or(Ok(()), Err);
+				self.service.published.lock().unwrap().shutdown = Some(result);
+				self.waker.wake();
+				break;
+			}
+			let mut deadline = now + Duration::from_secs(86400);
+			if !self.closing && !self.in_flight && self.active.is_some() {
+				deadline = deadline.min(self.next_fetch.max(now + Duration::from_millis(100)));
+			}
+			if !self.saving && self.writable && self.saved != self.revision {
+				deadline = deadline.min(self.next_save);
+			}
+			match rx.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
+				Ok(command) => self.command(command),
+				Err(mpsc::RecvTimeoutError::Timeout) => (),
+				Err(mpsc::RecvTimeoutError::Disconnected) => break,
+			}
+		}
+	}
+	fn command(&mut self, command: Command) {
+		match command {
+			Command::Select(id) if !self.closing => {
+				if self.service.published.lock().unwrap().removed.contains(&id) {
+					return;
+				}
+				self.active = None;
+				let account = self.accounts.entry(id.clone()).or_default();
+				account.sources[0].error =
+					Some("User autocomplete is unavailable until account credentials can be verified.".into());
+				self.publish(&id);
+			}
+			Command::Activate(id, credentials) if !self.closing => {
+				if self.service.published.lock().unwrap().removed.contains(&id) {
+					return;
+				}
+				let generation = self.generations.entry(id.clone()).or_insert(1);
+				if self.credentials.get(&id).is_some_and(|previous| previous != &credentials) {
+					*generation += 1;
+				}
+				let account = self.accounts.entry(id.clone()).or_default();
+				for source in &mut account.sources {
+					source.paused = false;
+					source.retry = None;
+					source.error = None;
+				}
+				self.credentials.insert(id.clone(), credentials);
+				self.active = Some(id.clone());
+				self.next_fetch = self.next_fetch.min(Instant::now() + Duration::from_secs(2));
+				self.publish(&id);
+			}
+			Command::Pause => {
+				self.active = None;
+			}
+			Command::Remove(id) => {
+				*self.gate.lock().unwrap() += 1;
+				*self.generations.entry(id.clone()).or_default() += 1;
+				self.accounts.remove(&id);
+				self.credentials.remove(&id);
+				if self.active.as_ref() == Some(&id) {
+					self.active = None;
+				}
+				self.service.published.lock().unwrap().snapshots.remove(&id);
+				self.changed(&id);
+				self.next_save = Instant::now();
+			}
+			Command::Interaction(id, entry, follow) if !self.closing => {
+				if let Some(account) = self.accounts.get_mut(&id) {
+					account.revision = self.revision + 1;
+					if follow {
+						account.following.insert(entry.id.clone());
+						account.scanning_following.insert(entry.id.clone());
+					}
+					account.merge(entry, u64::MAX, true);
+					self.changed(&id);
+				}
+			}
+			Command::Relationship(id, target, change) if !self.closing => {
+				if let Some(account) = self.accounts.get_mut(&id) {
+					account.revision = self.revision + 1;
+					account.relationship(&target, change);
+					self.changed(&id);
+				}
+			}
+			Command::ObservedRelationships(id, relationships, issued) if !self.closing => {
+				if let Some(account) = self.accounts.get_mut(&id) {
+					account.revision = self.revision + 1;
+					for relationship in relationships {
+						// Unchanged observations must not invalidate entries in pending pages.
+						if account.target_revisions.get(&relationship.id).is_none_or(|r| *r <= issued)
+							&& account.blocked.contains(&relationship.id) != relationship.blocking
+						{
+							account.relationship(
+								&relationship.id,
+								if relationship.blocking { Change::Block } else { Change::Unblock },
+							);
+						}
+					}
+					self.changed(&id);
+				}
+			}
+			Command::Fetched(job, result, status) => {
+				self.in_flight = false;
+				if self.closing || self.generations.get(&job.owner) != Some(&job.generation) {
+					return;
+				}
+				self.fetched(&job, result, status);
+			}
+			Command::RequestStarted(id, generation) if !self.closing => {
+				if self.generations.get(&id) == Some(&generation)
+					&& let Some(account) = self.accounts.get_mut(&id)
+					&& let Some(timing) = &mut account.build_timing
+					&& timing.completed_at.is_none()
+				{
+					timing.record_request();
+					// Counting affects persistence only; searchable entries have not changed.
+					self.revision += 1;
+					account.revision = self.revision;
+				}
+			}
+			Command::Saved(revision, result) => {
+				self.saving = false;
+				match result {
+					Ok(true) => {
+						self.saved = revision;
+						self.persistence_error = None;
+						self.save_attempt = 0;
+						self.next_save = Instant::now() + Duration::from_secs(2);
+					}
+					Ok(false) => {
+						self.next_save = Instant::now();
+						self.final_attempt = false;
+					}
+					Err(error) => {
+						self.persistence_error = Some(error);
+						self.next_save = Instant::now() + rate::backoff(self.save_attempt);
+						self.save_attempt += 1;
+					}
+				}
+				for id in self.accounts.keys() {
+					self.publish(id);
+				}
+			}
+			Command::Shutdown if !self.closing => {
+				self.closing = true;
+				self.active = None;
+				let _ = self.disk.send(DiskCommand::FlushLog);
+			}
+			Command::LogFlushed(result) => {
+				self.log_flushed = true;
+				self.log_error = result.err();
+			}
+			_ => (),
+		}
+	}
+	fn schedule(&mut self, now: Instant, unix_now: i64, foreground_busy: bool) {
+		// Selection and shutdown are published synchronously, before their queued commands.
+		if self.service.published.lock().unwrap().active != self.active {
+			return;
+		}
+		if self.in_flight || now < self.next_fetch {
+			return;
+		}
+		let Some(id) = self.active.clone() else {
+			return;
+		};
+		let Some(credentials) = self.credentials.get(&id).cloned() else {
+			return;
+		};
+		if foreground_busy {
+			self.next_fetch = now + Duration::from_millis(200);
+			return;
+		}
+		if let Some(deadline) = rate::defer_until(&credentials.base.origin().ascii_serialization(), now) {
+			self.next_fetch = deadline;
+			if let Some(account) = self.accounts.get_mut(&id) {
+				account.sources[0].error =
+					Some("User autocomplete is unavailable while waiting for the server rate limit.".into());
+			}
+			self.publish(&id);
+			return;
+		}
+		let account = self.accounts.get_mut(&id).unwrap();
+		if account.sources.iter().all(|s| s.done) && account.confirm.is_empty() {
+			let due = account.last_complete.unwrap_or(0) + 86400;
+			let remaining = due - unix_now;
+			if remaining > 0 {
+				self.next_fetch = now + Duration::from_secs(remaining.unsigned_abs());
+				return;
+			}
+			account.sources = Default::default();
+			account.scanning_following.clear();
+			account.scan_revision = account.revision;
+		}
+		let source = if !account.confirm.is_empty()
+			&& !account.sources[0].paused
+			&& account.sources[0].retry.is_none_or(|d| d <= now)
+		{
+			0
+		} else {
+			let Some(source) =
+				account.sources.iter().position(|s| !s.done && !s.paused && s.retry.is_none_or(|d| d <= now))
+			else {
+				self.next_fetch = account
+					.sources
+					.iter()
+					.filter_map(|s| s.retry)
+					.filter(|d| *d > now)
+					.min()
+					.unwrap_or(now + Duration::from_secs(86400));
+				return;
+			};
+			source
+		};
+		if account.sources[source].paused {
+			self.next_fetch = now + Duration::from_secs(86400);
+			return;
+		}
+		if let Some(deadline) = account.sources[source].retry.filter(|d| *d > now) {
+			self.next_fetch = deadline;
+			return;
+		}
+		let job = Job {
+			owner: id.clone(),
+			generation: self.generations[&id],
+			revision: account.revision,
+			source,
+			next: account.sources[source].next.clone(),
+			confirm: if source == 0 { account.confirm.iter().take(80).cloned().collect() } else { Vec::new() },
+			credentials,
+		};
+		if account.build_timing.as_ref().is_none_or(|timing| timing.completed_at.is_some()) {
+			let started_on_resume = account.sources.iter().any(|s| s.done || s.next.is_some() || !s.seen.is_empty())
+				|| !account.confirm.is_empty();
+			let timing = timing::BuildTiming::new(unix_now, started_on_resume);
+			let _ = self.disk.send(DiskCommand::Log(timing.start_message(&id)));
+			account.build_timing = Some(timing);
+			self.changed(&id);
+		}
+		self.in_flight = true;
+		self.next_fetch = now + Duration::from_secs(2);
+		let _ = self.fetch.send(job);
+	}
+	fn fetched(&mut self, job: &Job, result: Result<Fetched, String>, status: Option<u16>) {
+		let Some(account) = self.accounts.get_mut(&job.owner) else {
+			return;
+		};
+		let was_complete = account.sources.iter().all(|s| s.done) && account.confirm.is_empty();
+		account.revision = self.revision + 1;
+		match result {
+			Ok(Fetched::Page(entries, next)) => {
+				for entry in entries {
+					if job.source == 0 && account.target_revisions.get(&entry.id).is_none_or(|r| *r <= job.revision) {
+						account.scanning_following.insert(entry.id.clone());
+					}
+					account.merge(entry, job.revision, false);
+				}
+				let source = &mut account.sources[job.source];
+				if let Some(cursor) = &job.next {
+					source.seen.insert(cursor.clone());
+				}
+				if next.as_ref().is_some_and(|cursor| source.seen.contains(cursor)) {
+					source.paused = true;
+					source.error =
+						Some("User autocomplete is unavailable: the server repeated a pagination link.".into());
+				} else {
+					source.done = next.is_none();
+					source.next = next;
+					source.retry = None;
+					source.attempt = 0;
+					source.error = None;
+					if source.done && job.source == 0 {
+						account.confirm = account.following.difference(&account.scanning_following).cloned().collect();
+						account.following.clone_from(&account.scanning_following);
+					}
+				}
+			}
+			Ok(Fetched::Relationships(relationships)) => {
+				for relationship in relationships {
+					if account
+						.target_revisions
+						.get(&relationship.id)
+						.is_none_or(|r| *r <= job.revision.min(account.scan_revision))
+					{
+						if relationship.blocking {
+							account.relationship(&relationship.id, Change::Block);
+						} else {
+							account.relationship(&relationship.id, Change::Unblock);
+						}
+						if relationship.following {
+							account.following.insert(relationship.id);
+						} else {
+							account.relationship(&relationship.id, Change::Unfollow);
+						}
+					}
+				}
+				account.confirm.retain(|id| !job.confirm.contains(id));
+				account.sources[0].retry = None;
+				account.sources[0].error = None;
+			}
+			Err(error) => {
+				let source = &mut account.sources[job.source];
+				if matches!(status, Some(401 | 403)) {
+					source.paused = true;
+				} else {
+					if matches!(status, Some(400 | 404 | 410 | 422)) && job.next.is_some() {
+						source.next = None;
+						source.seen.clear();
+						if job.source == 0 {
+							account.scanning_following.clear();
+						}
+					}
+					let reported = if status == Some(429) {
+						rate::reported_retry(&job.credentials.base.origin().ascii_serialization())
+					} else {
+						None
+					};
+					source.retry = Some(reported.unwrap_or_else(|| Instant::now() + rate::backoff(source.attempt)));
+					source.attempt += 1;
+				}
+				source.error = Some(if source.paused {
+					format!("User autocomplete is unavailable: access was denied ({error}).")
+				} else {
+					format!("User autocomplete is unavailable; retrying after a server or network failure ({error}).")
+				});
+			}
+		}
+		if !was_complete && account.sources.iter().all(|s| s.done) && account.confirm.is_empty() {
+			let completed_at = chrono::Utc::now().timestamp();
+			account.last_complete = Some(completed_at);
+			if let Some(timing) = &mut account.build_timing
+				&& let Some(message) = timing.finish(&job.owner, completed_at)
+			{
+				let _ = self.disk.send(DiskCommand::Log(message));
+			}
+			self.next_save = Instant::now();
+		}
+		self.changed(&job.owner);
+	}
+}
+
+fn fetch_job(job: &Job, request_started: impl FnOnce()) -> anyhow::Result<Fetched> {
+	let client = MastodonClient::for_autocomplete(job.credentials.base.clone())?;
+	if !job.confirm.is_empty() {
+		let relationships = client.get_relationships_observed(&job.credentials.token, &job.confirm, request_started)?;
+		anyhow::ensure!(
+			job.confirm.iter().all(|id| relationships.iter().any(|r| &r.id == id)),
+			"Incomplete relationship confirmation response"
+		);
+		return Ok(Fetched::Relationships(relationships));
+	}
+	let page = client.autocomplete_page_observed(
+		&job.credentials.token,
+		&job.credentials.user_id,
+		job.source == 0,
+		job.next.as_deref(),
+		request_started,
+	)?;
+	Ok(Fetched::Page(page.accounts.iter().map(|a| Entry::from_account(a, &job.credentials.base)).collect(), page.next))
+}

--- a/src/autocomplete/rate.rs
+++ b/src/autocomplete/rate.rs
@@ -1,0 +1,90 @@
+//! Shared request budget for foreground clients and the background cache worker.
+use std::{
+	collections::HashMap,
+	sync::{
+		Mutex, OnceLock,
+		atomic::{AtomicUsize, Ordering},
+	},
+	time::{Duration, Instant},
+};
+
+use reqwest::blocking::Response;
+
+pub static FOREGROUND: AtomicUsize = AtomicUsize::new(0);
+static BUDGETS: OnceLock<Mutex<HashMap<String, Budget>>> = OnceLock::new();
+
+#[derive(Clone, Copy, Default)]
+struct Budget {
+	limit: Option<u64>,
+	remaining: Option<u64>,
+	reset: Option<Instant>,
+	retry: Option<Instant>,
+	retry_explicit: bool,
+}
+
+pub struct ForegroundGuard;
+pub fn foreground() -> ForegroundGuard {
+	FOREGROUND.fetch_add(1, Ordering::SeqCst);
+	ForegroundGuard
+}
+impl Drop for ForegroundGuard {
+	fn drop(&mut self) {
+		FOREGROUND.fetch_sub(1, Ordering::SeqCst);
+	}
+}
+
+pub fn observe(response: &Response) {
+	let mut budgets = BUDGETS.get_or_init(Mutex::default).lock().unwrap();
+	let budget = budgets.entry(response.url().origin().ascii_serialization()).or_default();
+	let headers = response.headers();
+	let value = |name| headers.get(name).and_then(|h| h.to_str().ok());
+	if let Some(limit) = value("x-ratelimit-limit").and_then(|s| s.parse().ok()) {
+		budget.limit = Some(limit);
+	}
+	if let Some(remaining) = value("x-ratelimit-remaining").and_then(|s| s.parse().ok()) {
+		budget.remaining = Some(remaining);
+	}
+	if let Some(reset) = value("x-ratelimit-reset").and_then(deadline) {
+		budget.reset = Some(reset);
+	}
+	if response.status().as_u16() == 429 {
+		budget.retry = value("retry-after").and_then(|s| {
+			s.parse::<u64>()
+				.ok()
+				.and_then(|n| Instant::now().checked_add(Duration::from_secs(n)))
+				.or_else(|| deadline(s))
+		});
+		budget.retry = budget.retry.max(budget.reset);
+		budget.retry_explicit = budget.retry.is_some_and(|d| d > Instant::now());
+		budget.retry =
+			budget.retry.filter(|d| *d > Instant::now()).or_else(|| Some(Instant::now() + Duration::from_secs(30)));
+	}
+	drop(budgets);
+}
+
+fn deadline(value: &str) -> Option<Instant> {
+	let date =
+		chrono::DateTime::parse_from_rfc3339(value).or_else(|_| chrono::DateTime::parse_from_rfc2822(value)).ok()?;
+	let remaining = date.signed_duration_since(chrono::Utc::now()).to_std().unwrap_or(Duration::ZERO);
+	Instant::now().checked_add(remaining)
+}
+
+pub fn reported_retry(origin: &str) -> Option<Instant> {
+	let budget = *BUDGETS.get_or_init(Mutex::default).lock().unwrap().get(origin)?;
+	if budget.retry_explicit { budget.retry } else { None }
+}
+
+pub fn defer_until(origin: &str, now: Instant) -> Option<Instant> {
+	let budgets = BUDGETS.get_or_init(Mutex::default).lock().unwrap();
+	let budget = *budgets.get(origin)?;
+	drop(budgets);
+	let reserve = budget.limit.map_or(10, |limit| 10.max(limit.div_ceil(10)).min(limit.saturating_sub(1)));
+	let low = budget.remaining.is_some_and(|n| n <= reserve);
+	budget.retry.filter(|d| *d > now).max(if low { budget.reset.filter(|d| *d > now) } else { None })
+}
+
+pub fn backoff(attempt: u32) -> Duration {
+	let seconds = 30_u64.saturating_mul(1_u64 << attempt.min(4)).min(300);
+	let jitter = u64::from(chrono::Utc::now().timestamp_subsec_millis()) % 4;
+	Duration::from_secs((seconds + jitter).min(300))
+}

--- a/src/autocomplete/storage.rs
+++ b/src/autocomplete/storage.rs
@@ -1,0 +1,132 @@
+use std::{
+	collections::{HashMap, HashSet},
+	fs::{self, File},
+	io::{self, Write},
+	path::Path,
+	sync::{Arc, Mutex},
+};
+
+use serde::{Deserialize, Serialize};
+
+use super::AccountCache;
+
+#[derive(Serialize, Deserialize)]
+pub struct FileData {
+	pub version: u32,
+	pub accounts: HashMap<String, AccountCache>,
+}
+
+pub struct Loaded {
+	pub accounts: HashMap<String, AccountCache>,
+	pub error: Option<String>,
+	pub writable: bool,
+}
+
+pub fn append_log(path: &Path, message: &str) -> io::Result<()> {
+	if let Some(parent) = path.parent() {
+		fs::create_dir_all(parent)?;
+	}
+	let mut file = fs::OpenOptions::new().create(true).append(true).open(path)?;
+	writeln!(file, "{message}")?;
+	file.flush()
+}
+
+pub fn load(path: &Path, configured: &HashSet<String>) -> Loaded {
+	let mut loaded = Loaded { accounts: HashMap::new(), error: None, writable: true };
+	let bytes = match fs::read(path) {
+		Ok(bytes) => bytes,
+		Err(error) if error.kind() == io::ErrorKind::NotFound => return loaded,
+		Err(error) => {
+			loaded.error = Some(error.to_string());
+			loaded.writable = false;
+			return loaded;
+		}
+	};
+	let value = serde_json::from_slice::<serde_json::Value>(&bytes);
+	if let Ok(value) = &value
+		&& value.get("version").and_then(serde_json::Value::as_u64).is_some_and(|v| v > 1)
+	{
+		loaded.writable = false;
+		loaded.error = Some("Autocomplete persistence is unavailable: the cache uses a newer schema.".into());
+		return loaded;
+	}
+	let mut corrupt = true;
+	if let Ok(value) = value
+		&& value.get("version").and_then(serde_json::Value::as_u64) == Some(1)
+		&& let Some(accounts) = value.get("accounts").and_then(serde_json::Value::as_object)
+	{
+		corrupt = false;
+		for (id, value) in accounts {
+			if !configured.contains(id) {
+				continue;
+			}
+			match serde_json::from_value::<AccountCache>(value.clone()) {
+				Ok(account) if account.valid() => {
+					loaded.accounts.insert(id.clone(), account);
+				}
+				_ => {
+					corrupt = true;
+				}
+			}
+		}
+	}
+	if corrupt {
+		let backup = path.with_extension(format!("corrupt-{}.json", chrono::Utc::now().timestamp_millis()));
+		if let Err(error) = fs::copy(path, backup) {
+			loaded.writable = false;
+			loaded.error = Some(format!("Could not preserve corrupt autocomplete cache: {error}"));
+		}
+	}
+	loaded
+}
+
+/// Only replacement holds the removal gate. Serialization and flushing never block mutations.
+pub fn save(path: &Path, data: &FileData, epoch: u64, gate: &Arc<Mutex<u64>>) -> io::Result<bool> {
+	if let Some(parent) = path.parent() {
+		fs::create_dir_all(parent)?;
+	}
+	let temporary = path.with_extension("json.tmp");
+	let result = (|| {
+		let mut file = File::create(&temporary)?;
+		serde_json::to_writer(&mut file, data)?;
+		file.flush()?;
+		file.sync_all()?;
+		drop(file);
+		let current = gate.lock().unwrap();
+		if *current != epoch {
+			return Ok(false);
+		}
+		replace(&temporary, path)?;
+		drop(current);
+		Ok(true)
+	})();
+	if temporary.exists() {
+		let _ = fs::remove_file(&temporary);
+	}
+	result
+}
+
+#[cfg(windows)]
+fn replace(source: &Path, destination: &Path) -> io::Result<()> {
+	use std::os::windows::ffi::OsStrExt;
+
+	use windows::{
+		Win32::Storage::FileSystem::{MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW},
+		core::PCWSTR,
+	};
+	let source: Vec<u16> = source.as_os_str().encode_wide().chain([0]).collect();
+	let destination: Vec<u16> = destination.as_os_str().encode_wide().chain([0]).collect();
+	unsafe {
+		MoveFileExW(
+			PCWSTR(source.as_ptr()),
+			PCWSTR(destination.as_ptr()),
+			MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+		)
+	}
+	.map_err(io::Error::other)
+}
+
+#[cfg(not(windows))]
+fn replace(source: &Path, destination: &Path) -> io::Result<()> {
+	fs::rename(source, destination)
+}

--- a/src/autocomplete/tests.rs
+++ b/src/autocomplete/tests.rs
@@ -1,0 +1,909 @@
+use std::{
+	fs,
+	sync::atomic::{AtomicU64, Ordering},
+};
+
+use super::*;
+
+static TEMP_ID: AtomicU64 = AtomicU64::new(0);
+static MOCK_NETWORK: Mutex<()> = Mutex::new(());
+struct TestDirectory(PathBuf);
+impl TestDirectory {
+	fn new() -> Self {
+		let path = std::env::temp_dir().join(format!(
+			"fedra-autocomplete-{}-{}",
+			std::process::id(),
+			TEMP_ID.fetch_add(1, Ordering::Relaxed)
+		));
+		fs::create_dir_all(&path).unwrap();
+		Self(path)
+	}
+	fn cache(&self) -> PathBuf {
+		self.0.join("autocomplete-cache.json")
+	}
+}
+impl Drop for TestDirectory {
+	fn drop(&mut self) {
+		let _ = fs::remove_dir_all(&self.0);
+	}
+}
+
+fn entry(id: &str, address: &str) -> Entry {
+	Entry { id: id.into(), address: address.into(), display_name: "Alice".into(), revision: 0, unavailable: false }
+}
+
+fn model() -> (Coordinator, mpsc::Receiver<Job>) {
+	let (tx, _) = mpsc::channel();
+	let service = Service { tx, published: Arc::new(Mutex::new(Published::default())) };
+	let (fetch, jobs) = mpsc::channel();
+	let (disk, _) = mpsc::channel();
+	let credentials = Credentials {
+		base: url::Url::parse("https://test.invalid/").unwrap(),
+		token: "secret".into(),
+		user_id: "me".into(),
+	};
+	let coordinator = Coordinator {
+		accounts: HashMap::from([("a".into(), AccountCache::default()), ("b".into(), AccountCache::default())]),
+		credentials: HashMap::from([("a".into(), credentials.clone()), ("b".into(), credentials)]),
+		generations: HashMap::from([("a".into(), 1), ("b".into(), 1)]),
+		active: Some("a".into()),
+		service,
+		waker: UiWaker::silent(),
+		gate: Arc::new(Mutex::new(0)),
+		fetch,
+		disk,
+		log_flushed: false,
+		log_error: None,
+		in_flight: false,
+		saving: false,
+		revision: 0,
+		saved: 0,
+		next_fetch: Instant::now(),
+		next_save: Instant::now(),
+		save_attempt: 0,
+		persistence_error: None,
+		writable: true,
+		closing: false,
+		final_attempt: false,
+	};
+	coordinator.service.published.lock().unwrap().active = Some("a".into());
+	for id in ["a", "b"] {
+		coordinator.publish(id);
+	}
+	(coordinator, jobs)
+}
+
+fn job(coordinator: &Coordinator, owner: &str, source: usize) -> Job {
+	Job {
+		owner: owner.into(),
+		generation: coordinator.generations[owner],
+		revision: coordinator.accounts[owner].revision,
+		source,
+		next: coordinator.accounts[owner].sources[source].next.clone(),
+		confirm: Vec::new(),
+		credentials: coordinator.credentials[owner].clone(),
+	}
+}
+
+fn page(coordinator: &mut Coordinator, job: Job, entries: Vec<Entry>, next: Option<&str>) {
+	coordinator.command(Command::Fetched(job, Ok(Fetched::Page(entries, next.map(str::to_owned))), None));
+}
+
+#[test]
+fn prefixes_and_one_hundred_thousand_entries() {
+	let mut account = AccountCache::default();
+	for i in 0..100_000 {
+		let mut e = entry(&i.to_string(), &format!("@user{i:05}@example.org"));
+		e.display_name = format!("Person {i:05}");
+		account.entries.insert(e.id.clone(), e);
+	}
+	let snapshot = account.snapshot(None);
+	let started = Instant::now();
+	for _ in 0..1000 {
+		assert_eq!(snapshot.matching("  @USER123  ").len(), 100);
+		assert_eq!(snapshot.matching("user12345@exa").len(), 1);
+		assert_eq!(snapshot.matching(" @PERSON 123 ").len(), 100);
+		assert_eq!(snapshot.matching("example").len(), 0);
+		assert_eq!(snapshot.matching("@@user").len(), 0);
+		assert_eq!(snapshot.matching(" @ ").len(), 100_000);
+		assert_eq!(snapshot.matching("  ").len(), 100_000);
+	}
+	assert_eq!(snapshot.matching("person").len(), 100_000);
+	assert!(started.elapsed() < Duration::from_secs(2), "Prefix lookup unexpectedly slow: {:?}", started.elapsed());
+}
+
+#[test]
+fn display_name_prefixes_merge_with_addresses_and_follow_metadata_changes() {
+	let mut account = AccountCache::default();
+	for (id, address, name) in [
+		("zach", "@ZBennoui@dragonscave.space", "Zach Bennoui"),
+		("both", "@zara@example.org", "Zara"),
+		("address", "@zane@example.org", ""),
+		("name", "@aaron@example.org", "  Zander  "),
+		("other", "@bob@example.org", "Bob"),
+		("unicode", "@emile@example.org", "Émile"),
+	] {
+		let mut e = entry(id, address);
+		e.display_name = name.into();
+		account.merge(e, 0, true);
+	}
+	let snapshot = account.snapshot(None);
+	let ids = |snapshot: &Snapshot, query: &str| {
+		let matches = snapshot.matching(query);
+		(0..matches.len()).map(|row| snapshot.entries[matches.get(row).unwrap()].1.id.clone()).collect::<Vec<_>>()
+	};
+	for query in ["za", "@za", "  @ZA  "] {
+		assert_eq!(ids(&snapshot, query), ["name", "address", "both", "zach"]);
+	}
+	assert_eq!(ids(&snapshot, "zach ben"), ["zach"]);
+	assert_eq!(ids(&snapshot, "@zbennoui@dragons"), ["zach"]);
+	assert_eq!(ids(&snapshot, "@ÉM"), ["unicode"]);
+	for query in ["bennoui", "dragonscave", "@@za", "missing"] {
+		assert!(ids(&snapshot, query).is_empty());
+	}
+	assert!(snapshot.matching("za").get(4).is_none());
+	for query in ["", " ", "@"] {
+		assert_eq!(snapshot.matching(query).len(), 6);
+	}
+	let mut updated = account.entries["zach"].clone();
+	updated.display_name = "Benjamin".into();
+	account.merge(updated, 0, true);
+	assert!(ids(&account.snapshot(None), "zach").is_empty());
+	assert_eq!(ids(&account.snapshot(None), "ben"), ["zach"]);
+	account.relationship("zach", Change::Unfollow);
+	assert!(ids(&account.snapshot(None), "ben").is_empty());
+	assert_eq!(ids(&snapshot, "zach"), ["zach"], "Published snapshots remain immutable");
+}
+
+#[test]
+fn partial_empty_and_failed_availability() {
+	let (mut c, _) = model();
+	assert!(matches!(c.accounts["a"].snapshot(None).availability, Availability::Building));
+	let request = job(&c, "a", 0);
+	page(&mut c, request, vec![], None);
+	assert!(matches!(c.accounts["a"].snapshot(None).availability, Availability::Building));
+	let request = job(&c, "a", 1);
+	c.command(Command::Fetched(request.clone(), Err("offline".into()), None));
+	assert!(matches!(c.accounts["a"].snapshot(None).availability, Availability::Unavailable(_)));
+	page(&mut c, request, vec![], None);
+	assert!(matches!(c.accounts["a"].snapshot(None).availability, Availability::CompletedEmpty));
+	let request = job(&c, "a", 0);
+	c.command(Command::Fetched(request, Err("offline".into()), None));
+	assert!(matches!(c.accounts["a"].snapshot(None).availability, Availability::CompletedEmpty));
+	c.command(Command::Interaction("b".into(), entry("1", "@alice@example.org"), false));
+	assert!(matches!(c.accounts["b"].snapshot(Some("write failed".into())).availability, Availability::UsablePartial));
+}
+
+#[test]
+fn checkpoints_replay_and_newer_interactions() {
+	let (mut c, _) = model();
+	let old = job(&c, "a", 0);
+	c.command(Command::Interaction("a".into(), entry("1", "@new@example.org"), false));
+	page(
+		&mut c,
+		old.clone(),
+		vec![entry("1", "@old@example.org")],
+		Some("https://test.invalid/api/v1/accounts/me/following?cursor=opaque"),
+	);
+	assert_eq!(c.accounts["a"].entries["1"].address, "@new@example.org");
+	assert!(c.accounts["a"].sources[0].next.is_some());
+	page(
+		&mut c,
+		old,
+		vec![entry("1", "@old@example.org")],
+		Some("https://test.invalid/api/v1/accounts/me/following?cursor=opaque"),
+	);
+	assert_eq!(c.accounts["a"].entries.len(), 1);
+	let next = job(&c, "a", 0);
+	page(&mut c, next.clone(), vec![], next.next.as_deref());
+	assert!(c.accounts["a"].sources[0].paused);
+	assert!(!c.accounts["a"].sources[0].done);
+}
+
+#[test]
+fn exclusions_dominate_pages_and_unblock_preserves_unfollow() {
+	let (mut c, _) = model();
+	let old = job(&c, "a", 0);
+	let alice = entry("1", "@alice@example.org");
+	c.command(Command::Relationship("a".into(), "1".into(), Change::Unfollow));
+	page(&mut c, old.clone(), vec![alice.clone()], None);
+	assert!(c.accounts["a"].entries.is_empty());
+	c.command(Command::Interaction("a".into(), alice.clone(), false));
+	page(&mut c, old, vec![entry("1", "@stale@example.org")], None);
+	assert_eq!(c.accounts["a"].entries["1"].address, alice.address);
+	c.command(Command::Relationship("a".into(), "1".into(), Change::Block));
+	c.command(Command::Relationship("a".into(), "1".into(), Change::Unfollow));
+	c.command(Command::Interaction("a".into(), alice.clone(), false));
+	c.command(Command::Relationship("a".into(), "1".into(), Change::Unblock));
+	assert!(c.accounts["a"].entries.is_empty());
+	assert!(c.accounts["a"].unfollowed.contains("1"));
+	c.command(Command::Interaction("a".into(), alice, false));
+	assert_eq!(c.accounts["a"].entries.len(), 1);
+}
+
+#[test]
+fn switching_removal_late_results_and_inactive_interactions() {
+	let (mut c, _) = model();
+	let old = job(&c, "a", 0);
+	c.command(Command::Activate("b".into(), c.credentials["b"].clone()));
+	page(&mut c, old.clone(), vec![entry("1", "@alice@example.org")], None);
+	assert!(c.accounts["b"].entries.is_empty());
+	c.command(Command::Interaction("a".into(), entry("2", "@bob@example.org"), false));
+	assert_eq!(c.accounts["a"].entries.len(), 2);
+	c.command(Command::Remove("a".into()));
+	page(&mut c, old, vec![entry("1", "@alice@example.org")], None);
+	c.command(Command::Interaction("a".into(), entry("2", "@bob@example.org"), false));
+	assert!(!c.accounts.contains_key("a"));
+	assert!(c.service.session("a".into()).snapshot().entries.is_empty());
+}
+
+#[test]
+fn scheduler_uses_injected_time_and_independent_sources() {
+	let (mut c, jobs) = model();
+	let now = Instant::now();
+	c.next_fetch = now;
+	c.schedule(now, 100, false);
+	let first = jobs.try_recv().unwrap();
+	assert_eq!(first.source, 0);
+	c.schedule(now + Duration::from_secs(20), 120, false);
+	assert!(jobs.try_recv().is_err(), "Only one request can be in flight");
+	page(&mut c, first, vec![], None);
+	c.schedule(now + Duration::from_secs(1), 101, false);
+	assert!(jobs.try_recv().is_err(), "Requests must be spaced");
+	c.schedule(now + Duration::from_secs(2), 102, false);
+	let second = jobs.try_recv().unwrap();
+	assert_eq!(second.source, 1);
+	c.command(Command::Fetched(second, Err("denied".into()), Some(403)));
+	assert!(c.accounts["a"].sources[0].done);
+	assert!(!c.accounts["a"].sources[1].done);
+	c.schedule(now + Duration::from_secs(300), 400, false);
+	assert!(jobs.try_recv().is_err());
+	c.command(Command::Activate("a".into(), c.credentials["a"].clone()));
+	c.schedule(now + Duration::from_secs(301), 401, false);
+	assert_eq!(jobs.try_recv().unwrap().source, 1);
+}
+
+#[test]
+fn interrupted_save_and_removal_cannot_replace_valid_file() {
+	let dir = TestDirectory::new();
+	let path = dir.cache();
+	let data = storage::FileData { version: 1, accounts: HashMap::from([("a".into(), AccountCache::default())]) };
+	let gate = Arc::new(Mutex::new(0));
+	assert!(storage::save(&path, &data, 0, &gate).unwrap());
+	let valid = fs::read(&path).unwrap();
+	*gate.lock().unwrap() = 1;
+	assert!(!storage::save(&path, &data, 0, &gate).unwrap());
+	assert_eq!(fs::read(&path).unwrap(), valid);
+	fs::create_dir(path.with_extension("json.tmp")).unwrap();
+	assert!(storage::save(&path, &data, 1, &gate).is_err());
+	assert_eq!(fs::read(&path).unwrap(), valid);
+	fs::remove_dir(path.with_extension("json.tmp")).unwrap();
+	let removed = storage::FileData { version: 1, accounts: HashMap::new() };
+	assert!(storage::save(&path, &removed, 1, &gate).unwrap());
+	assert!(storage::load(&path, &HashSet::from(["a".into()])).accounts.is_empty());
+}
+
+#[test]
+fn load_salvages_accounts_preserves_corruption_and_newer_schema() {
+	let dir = TestDirectory::new();
+	let path = dir.cache();
+	let account = AccountCache::default();
+	let data = serde_json::json!({"version":1,"accounts":{"a":account,"b":{"entries":"bad"},"removed":account}});
+	fs::write(&path, serde_json::to_vec(&data).unwrap()).unwrap();
+	let configured = HashSet::from(["a".into(), "b".into()]);
+	let loaded = storage::load(&path, &configured);
+	assert!(loaded.accounts.contains_key("a"));
+	assert!(!loaded.accounts.contains_key("b"));
+	assert!(!loaded.accounts.contains_key("removed"));
+	assert_eq!(fs::read_dir(&dir.0).unwrap().count(), 2);
+	fs::write(&path, b"{broken").unwrap();
+	assert!(storage::load(&path, &configured).accounts.is_empty());
+	fs::write(&path, b"{\"version\":2}").unwrap();
+	let loaded = storage::load(&path, &configured);
+	assert!(!loaded.writable);
+	assert!(loaded.error.is_some());
+	assert_eq!(fs::read(&path).unwrap(), b"{\"version\":2}");
+}
+
+#[test]
+fn saved_revision_does_not_clean_newer_mutations() {
+	let (mut c, _) = model();
+	c.command(Command::Interaction("a".into(), entry("1", "@alice@example.org"), false));
+	let saved = c.revision;
+	c.command(Command::Interaction("a".into(), entry("2", "@bob@example.org"), false));
+	c.command(Command::Saved(saved, Ok(true)));
+	assert!(c.revision > c.saved);
+	c.command(Command::Saved(c.revision, Err("disk full".into())));
+	assert!(c.revision > c.saved);
+	assert!(c.next_save > Instant::now());
+	assert_eq!(c.service.session("a".into()).snapshot().entries.len(), 2);
+}
+
+#[test]
+fn build_timing_survives_resuming_and_logs_completion_once() {
+	let (mut c, jobs) = model();
+	let (disk, messages) = mpsc::channel();
+	c.disk = disk;
+	let now = Instant::now();
+	let started = chrono::Utc::now().timestamp() - 134;
+	c.schedule(now, started, false);
+	let first = jobs.recv().unwrap();
+	c.command(Command::RequestStarted(first.owner.clone(), first.generation));
+	assert_eq!(c.accounts["a"].build_timing.as_ref().unwrap().started_at, started);
+	assert!(
+		matches!(messages.try_recv().unwrap(), DiskCommand::Log(message) if message.contains("build started") && message.contains("account \"a\""))
+	);
+	page(&mut c, first, vec![], None);
+	assert!(c.accounts["a"].build_timing.as_ref().unwrap().completed_at.is_none());
+	let dir = TestDirectory::new();
+	storage::save(&dir.cache(), &storage::FileData { version: 1, accounts: c.accounts.clone() }, 0, &c.gate).unwrap();
+	c.accounts = storage::load(&dir.cache(), &HashSet::from(["a".into(), "b".into()])).accounts;
+	assert_eq!(c.accounts["a"].build_timing.as_ref().unwrap().requests.as_ref().unwrap().attempts, 1);
+	c.schedule(now + Duration::from_secs(2), started + 2, false);
+	let second = jobs.recv().unwrap();
+	c.command(Command::RequestStarted(second.owner.clone(), second.generation));
+	c.command(Command::Fetched(second.clone(), Err("offline".into()), None));
+	assert!(c.accounts["a"].build_timing.as_ref().unwrap().completed_at.is_none());
+	assert!(messages.try_recv().is_err(), "Resume/retry must not restart timing");
+	c.command(Command::RequestStarted(second.owner.clone(), second.generation));
+	page(&mut c, second.clone(), vec![], None);
+	let timing = c.accounts["a"].build_timing.as_ref().unwrap();
+	assert_eq!(timing.started_at, started);
+	assert!(timing.completed_at.unwrap() >= started + 134);
+	assert!(
+		matches!(messages.try_recv().unwrap(), DiskCommand::Log(message) if message.contains("build completed") && message.contains("total duration: 2 minutes") && message.contains("API requests: 3"))
+	);
+	let completed = c.accounts["a"].last_complete;
+	page(&mut c, second, vec![], None);
+	assert_eq!(c.accounts["a"].last_complete, completed);
+	assert!(messages.try_recv().is_err(), "Replayed pages must not log a second completion");
+	c.schedule(now + Duration::from_secs(86401), completed.unwrap() + 86401, false);
+	let refreshed = c.accounts["a"].build_timing.as_ref().unwrap();
+	assert_eq!(refreshed.started_at, completed.unwrap() + 86401);
+	assert!(refreshed.completed_at.is_none());
+	assert!(!refreshed.started_on_resume);
+	assert_eq!(refreshed.requests.as_ref().unwrap().attempts, 0);
+	assert!(matches!(messages.try_recv().unwrap(), DiskCommand::Log(message) if message.contains("build started")));
+}
+
+#[test]
+fn legacy_partial_build_logs_only_time_since_resume() {
+	let (mut c, jobs) = model();
+	let (disk, messages) = mpsc::channel();
+	c.disk = disk;
+	let mut legacy = serde_json::to_value(&c.accounts["a"]).unwrap();
+	legacy.as_object_mut().unwrap().remove("build_timing");
+	legacy["sources"][0]["done"] = true.into();
+	c.accounts.insert("a".into(), serde_json::from_value(legacy).unwrap());
+	c.schedule(Instant::now(), chrono::Utc::now().timestamp(), false);
+	assert!(c.accounts["a"].build_timing.as_ref().unwrap().started_on_resume);
+	assert!(
+		matches!(messages.try_recv().unwrap(), DiskCommand::Log(message) if message.contains("Original start time is unknown"))
+	);
+	page(&mut c, jobs.recv().unwrap(), vec![], None);
+	assert!(
+		matches!(messages.try_recv().unwrap(), DiskCommand::Log(message) if message.contains("time since resume:") && !message.contains("total duration:"))
+	);
+}
+
+#[test]
+fn request_counts_follow_the_originating_account_and_generation() {
+	let (mut c, _) = model();
+	for account in c.accounts.values_mut() {
+		account.build_timing = Some(timing::BuildTiming::new(100, false));
+	}
+	c.command(Command::Pause);
+	c.command(Command::RequestStarted("a".into(), 1));
+	c.command(Command::RequestStarted("a".into(), 2));
+	assert_eq!(c.accounts["a"].build_timing.as_ref().unwrap().requests.as_ref().unwrap().attempts, 1);
+	assert_eq!(c.accounts["b"].build_timing.as_ref().unwrap().requests.as_ref().unwrap().attempts, 0);
+	c.command(Command::Remove("a".into()));
+	c.command(Command::RequestStarted("a".into(), 1));
+	assert!(!c.accounts.contains_key("a"));
+}
+
+#[test]
+fn mock_request_counts_include_failures_and_confirmation_batches() {
+	let _network = MOCK_NETWORK.lock().unwrap();
+	let mut failed = MockResponse::json(serde_json::json!([]));
+	failed.status = 503;
+	let (base, received) =
+		server(vec![failed, MockResponse::json(serde_json::json!([])), MockResponse::json(serde_json::json!([]))]);
+	let (c, _) = model();
+	let mut request = job(&c, "a", 0);
+	request.credentials.base = base;
+	let attempts = std::cell::Cell::new(0);
+	let observe = || attempts.set(attempts.get() + 1);
+	assert!(fetch_job(&request, observe).is_err());
+	assert!(fetch_job(&request, observe).is_ok());
+	request.confirm = vec!["one".into(), "two".into()];
+	// Even an incomplete confirmation response counts as one batch request.
+	assert!(fetch_job(&request, observe).is_err());
+	assert_eq!(attempts.get(), 3);
+	for _ in 0..3 {
+		received.recv_timeout(Duration::from_secs(3)).unwrap();
+	}
+	request.confirm.clear();
+	request.next = Some("https://foreign.invalid/api/v1/accounts/me/following".into());
+	assert!(fetch_job(&request, observe).is_err());
+	assert_eq!(attempts.get(), 3, "A locally rejected URL must not count as an API request");
+}
+
+#[test]
+fn shutdown_flushes_timing_log_and_reports_log_failure() {
+	for fail in [false, true] {
+		let dir = TestDirectory::new();
+		let log = dir.0.join("autocomplete.log");
+		if fail {
+			fs::create_dir(&log).unwrap();
+		} else {
+			fs::write(&log, "Previous build\n").unwrap();
+		}
+		let (tx, rx) = mpsc::channel();
+		let service = Service { tx, published: Arc::new(Mutex::new(Published::default())) };
+		let mut c = Coordinator::new(dir.cache(), HashSet::from(["a".into()]), service.clone(), UiWaker::silent());
+		let mut timing = timing::BuildTiming::new(100, false);
+		c.disk.send(DiskCommand::Log(timing.start_message("a"))).unwrap();
+		c.disk.send(DiskCommand::Log(timing.finish("a", 234).unwrap())).unwrap();
+		service.shutdown();
+		service.shutdown();
+		c.run(&rx);
+		let result = service.shutdown_result().unwrap();
+		assert_eq!(result.is_err(), fail);
+		assert!(dir.cache().is_file(), "Log failures must not stop cache saving");
+		if fail {
+			assert!(result.unwrap_err().contains("autocomplete.log"));
+		} else {
+			let text = fs::read_to_string(log).unwrap();
+			assert_eq!(text.lines().count(), 3);
+			assert!(text.starts_with("Previous build\n"));
+			assert!(text.contains("total duration: 2 minutes 14 seconds"));
+		}
+	}
+}
+
+fn wait_for_shutdown(service: &Service) -> Result<(), String> {
+	let deadline = Instant::now() + Duration::from_secs(5);
+	loop {
+		if let Some(result) = service.shutdown_result() {
+			return result;
+		}
+		assert!(Instant::now() < deadline, "Shutdown did not cross the final-save barrier");
+		thread::sleep(Duration::from_millis(5));
+	}
+}
+
+#[test]
+fn asynchronous_load_queues_updates_and_shutdown_saves_them() {
+	let dir = TestDirectory::new();
+	let service = Service::start(dir.cache(), HashSet::from(["a".into()]), UiWaker::silent());
+	service.session("a".into()).interaction(entry("1", "@alice@example.org"));
+	service.shutdown();
+	wait_for_shutdown(&service).unwrap();
+	let loaded = storage::load(&dir.cache(), &HashSet::from(["a".into()]));
+	assert_eq!(loaded.accounts["a"].entries.len(), 1);
+	assert!(!fs::read_to_string(dir.cache()).unwrap().contains("secret"));
+}
+
+#[test]
+fn shutdown_new_schema_and_final_failure_preserve_previous_file() {
+	let dir = TestDirectory::new();
+	fs::write(dir.cache(), b"{\"version\":2}").unwrap();
+	let service = Service::start(dir.cache(), HashSet::from(["a".into()]), UiWaker::silent());
+	service.session("a".into()).interaction(entry("1", "@alice@example.org"));
+	service.shutdown();
+	assert!(wait_for_shutdown(&service).is_err());
+	assert_eq!(fs::read(dir.cache()).unwrap(), b"{\"version\":2}");
+	let data = storage::FileData { version: 1, accounts: HashMap::new() };
+	storage::save(&dir.cache(), &data, 0, &Arc::new(Mutex::new(0))).unwrap();
+	let before = fs::read(dir.cache()).unwrap();
+	fs::create_dir(dir.cache().with_extension("json.tmp")).unwrap();
+	let service = Service::start(dir.cache(), HashSet::from(["a".into()]), UiWaker::silent());
+	service.session("a".into()).interaction(entry("1", "@alice@example.org"));
+	service.shutdown();
+	assert!(wait_for_shutdown(&service).is_err());
+	assert_eq!(fs::read(dir.cache()).unwrap(), before);
+}
+
+fn relationship(id: &str, following: bool, blocking: bool) -> Relationship {
+	serde_json::from_value(serde_json::json!({"id":id,"following":following,"blocking":blocking,"showing_reblogs":true,"notifying":false,"followed_by":false,"muting":false,"muting_notifications":false,"requested":false,"domain_blocking":false,"endorsed":false,"note":""})).unwrap()
+}
+
+#[test]
+fn unchanged_relationship_observation_preserves_inflight_following_page() {
+	for cached in [false, true] {
+		let (mut c, _) = model();
+		if cached {
+			c.command(Command::Interaction("a".into(), entry("1", "@old@example.org"), true));
+		}
+		let pending = job(&c, "a", 0);
+		c.command(Command::ObservedRelationships("a".into(), vec![relationship("1", true, false)], c.revision));
+		let cursor = "https://test.invalid/api/v1/accounts/me/following?cursor=next";
+		page(&mut c, pending, vec![entry("1", "@alice@example.org")], Some(cursor));
+		assert_eq!(c.accounts["a"].sources[0].next.as_deref(), Some(cursor));
+		let snapshot = c.service.session("a".into()).snapshot();
+		assert_eq!(snapshot.entries.len(), 1, "The pending page must publish its entry");
+		assert_eq!(snapshot.entries[0].1.address, "@alice@example.org");
+		let next = job(&c, "a", 0);
+		page(&mut c, next, vec![], None);
+		let followers = job(&c, "a", 1);
+		page(&mut c, followers, vec![], None);
+		assert!(c.accounts["a"].following.contains("1"));
+		assert!(c.accounts["a"].confirm.is_empty());
+		let snapshot = c.service.session("a".into()).snapshot();
+		assert_eq!(snapshot.entries[0].1.address, "@alice@example.org");
+		assert!(matches!(snapshot.availability, Availability::Usable));
+	}
+}
+
+#[test]
+fn changed_blocking_observation_still_invalidates_inflight_pages() {
+	for was_blocked in [false, true] {
+		let (mut c, _) = model();
+		if was_blocked {
+			c.command(Command::Relationship("a".into(), "1".into(), Change::Block));
+		}
+		let pending = job(&c, "a", 0);
+		c.command(Command::ObservedRelationships("a".into(), vec![relationship("1", true, !was_blocked)], c.revision));
+		page(&mut c, pending, vec![entry("1", "@stale@example.org")], None);
+		assert!(c.accounts["a"].entries.is_empty());
+		assert!(!c.accounts["a"].following.contains("1"));
+		assert_eq!(c.accounts["a"].blocked.contains("1"), !was_blocked);
+	}
+}
+
+#[test]
+fn authoritative_refresh_confirms_missing_following_and_rejects_stale_relationships() {
+	let (mut c, _) = model();
+	c.command(Command::Interaction("a".into(), entry("1", "@alice@example.org"), true));
+	c.accounts.get_mut("a").unwrap().scan_revision = c.revision;
+	c.accounts.get_mut("a").unwrap().scanning_following.clear();
+	let request = job(&c, "a", 0);
+	page(&mut c, request, vec![], None);
+	assert_eq!(c.accounts["a"].confirm, ["1"]);
+	assert!(c.accounts["a"].entries.contains_key("1"));
+	let mut confirmation = job(&c, "a", 0);
+	confirmation.confirm = vec!["1".into()];
+	c.command(Command::Fetched(confirmation, Ok(Fetched::Relationships(vec![relationship("1", false, false)])), None));
+	assert!(c.accounts["a"].unfollowed.contains("1"));
+	assert!(!c.accounts["a"].entries.contains_key("1"));
+	let issued = c.revision;
+	c.command(Command::Relationship("a".into(), "1".into(), Change::Block));
+	c.command(Command::ObservedRelationships("a".into(), vec![relationship("1", false, false)], issued));
+	assert!(c.accounts["a"].blocked.contains("1"));
+	c.command(Command::ObservedRelationships("a".into(), vec![relationship("1", false, false)], c.revision));
+	assert!(!c.accounts["a"].blocked.contains("1"));
+	assert!(c.accounts["a"].unfollowed.contains("1"));
+}
+
+struct MockResponse {
+	status: u16,
+	headers: String,
+	body: String,
+	delay: Duration,
+}
+impl MockResponse {
+	fn json(body: serde_json::Value) -> Self {
+		Self { status: 200, headers: String::new(), body: body.to_string(), delay: Duration::ZERO }
+	}
+}
+
+fn server(responses: Vec<MockResponse>) -> (url::Url, mpsc::Receiver<String>) {
+	let _ = rustls::crypto::ring::default_provider().install_default();
+	use std::{
+		io::{Read, Write},
+		net::TcpListener,
+	};
+	let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+	let base = url::Url::parse(&format!("http://{}/", listener.local_addr().unwrap())).unwrap();
+	let origin = base.origin().ascii_serialization();
+	let (sent, received) = mpsc::channel();
+	thread::spawn(move || {
+		listener.set_nonblocking(true).unwrap();
+		let deadline = Instant::now() + Duration::from_secs(10);
+		for response in responses {
+			let mut stream = loop {
+				match listener.accept() {
+					Ok((stream, _)) => break stream,
+					Err(error) if error.kind() == std::io::ErrorKind::WouldBlock && Instant::now() < deadline => {
+						thread::sleep(Duration::from_millis(5))
+					}
+					_ => return,
+				}
+			};
+			stream.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+			let mut request = Vec::new();
+			let mut buffer = [0; 4096];
+			while let Ok(n) = stream.read(&mut buffer) {
+				if n == 0 {
+					break;
+				}
+				request.extend_from_slice(&buffer[..n]);
+				if request.windows(4).any(|bytes| bytes == b"\r\n\r\n") {
+					break;
+				}
+			}
+			let _ = sent.send(String::from_utf8_lossy(&request).into_owned());
+			thread::sleep(response.delay);
+			let header = response.headers.replace("{origin}", &origin);
+			let wire = format!(
+				"HTTP/1.1 {} Test\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n{}\r\n{}",
+				response.status,
+				response.body.len(),
+				header,
+				response.body
+			);
+			let _ = stream.write_all(wire.as_bytes());
+		}
+	});
+	(base, received)
+}
+
+fn account_json(id: &str, acct: &str) -> serde_json::Value {
+	serde_json::json!({"id":id,"username":acct.split('@').next().unwrap(),"acct":acct,"display_name":"Alice","url":"https://example.org/@alice"})
+}
+
+fn unavailable_account_json(id: &str, moved: bool) -> serde_json::Value {
+	let mut account = account_json(id, "alice@old.example");
+	if moved {
+		account["moved"] = account_json("destination", "alice@new.example");
+	} else {
+		account["suspended"] = true.into();
+	}
+	account
+}
+
+#[test]
+fn unavailable_accounts_are_excluded_from_interactions_and_survive_restart() {
+	for moved in [false, true] {
+		for follow in [false, true] {
+			let (mut c, _) = model();
+			let active = entry("1", "@alice@old.example");
+			c.command(Command::Interaction("a".into(), active.clone(), follow));
+			let pending = job(&c, "a", 0);
+			let account: Account = serde_json::from_value(unavailable_account_json("1", moved)).unwrap();
+			let unavailable = Entry::from_account(&account, &pending.credentials.base);
+			c.command(Command::Interaction("a".into(), unavailable, follow));
+			assert!(c.service.session("a".into()).snapshot().entries.is_empty());
+			assert!(c.accounts["a"].unavailable.contains("1"));
+			assert!(!c.accounts["a"].entries.contains_key("destination"));
+			let dir = TestDirectory::new();
+			storage::save(&dir.cache(), &storage::FileData { version: 1, accounts: c.accounts.clone() }, 0, &c.gate)
+				.unwrap();
+			c.accounts = storage::load(&dir.cache(), &HashSet::from(["a".into(), "b".into()])).accounts;
+			// An older page or a cached reply/quote author cannot resurrect the old account.
+			page(&mut c, pending, vec![active.clone()], None);
+			c.command(Command::Interaction("a".into(), active.clone(), follow));
+			assert!(c.accounts["a"].entries.is_empty());
+			// A later page can establish that a suspension or redirect has been reversed.
+			let fresh = job(&c, "a", 1);
+			page(&mut c, fresh, vec![active], None);
+			assert!(!c.accounts["a"].unavailable.contains("1"));
+			assert_eq!(c.accounts["a"].entries.len(), 1);
+		}
+	}
+}
+
+#[test]
+fn stale_unavailable_pages_do_not_remove_newer_entries() {
+	let (mut c, _) = model();
+	let pending = job(&c, "a", 0);
+	let account: Account = serde_json::from_value(unavailable_account_json("1", true)).unwrap();
+	let unavailable = Entry::from_account(&account, &pending.credentials.base);
+	c.command(Command::Interaction("a".into(), entry("1", "@alice@example.org"), true));
+	page(&mut c, pending, vec![unavailable], None);
+	assert_eq!(c.accounts["a"].entries.len(), 1);
+	assert!(c.accounts["a"].unavailable.is_empty());
+	// Old cache files do not have the new exclusion set.
+	let mut legacy = serde_json::to_value(&c.accounts["a"]).unwrap();
+	legacy.as_object_mut().unwrap().remove("unavailable");
+	let restored: AccountCache = serde_json::from_value(legacy).unwrap();
+	assert!(restored.valid());
+	assert_eq!(restored.entries.len(), 1);
+}
+
+#[test]
+fn mock_pages_filter_unavailable_accounts_without_extra_requests() {
+	let _network = MOCK_NETWORK.lock().unwrap();
+	for source in [0, 1] {
+		let mut first = MockResponse::json(serde_json::json!([
+			unavailable_account_json("moved", true),
+			unavailable_account_json("suspended", false)
+		]));
+		let endpoint = if source == 0 { "following" } else { "followers" };
+		first.headers = format!("Link: <{{origin}}/api/v1/accounts/me/{endpoint}?cursor=next>; rel=\"next\"\r\n");
+		let mut active = account_json("active", "alice@one.example");
+		active["moved"] = serde_json::Value::Null;
+		active["suspended"] = false.into();
+		let (base, requests) = server(vec![
+			first,
+			MockResponse::json(serde_json::json!([active, account_json("other", "alice@two.example")])),
+		]);
+		let (mut c, _) = model();
+		c.credentials.get_mut("a").unwrap().base = base;
+		c.command(Command::Interaction("a".into(), entry("moved", "@alice@old.example"), false));
+		for _ in 0..2 {
+			let request = job(&c, "a", source);
+			let result = fetch_job(&request, || {}).unwrap();
+			c.command(Command::Fetched(request, Ok(result), None));
+			assert!(requests.recv_timeout(Duration::from_secs(2)).unwrap().contains(endpoint));
+			assert!(!c.accounts["a"].entries.contains_key("moved"));
+			assert!(!c.accounts["a"].entries.contains_key("suspended"));
+		}
+		assert!(requests.try_recv().is_err());
+		assert!(c.accounts["a"].sources[source].done);
+		assert_eq!(c.accounts["a"].entries.len(), 2, "Active accounts with the same username stay distinct");
+		assert!(c.accounts["a"].entries.contains_key("active"));
+		assert!(c.accounts["a"].entries.contains_key("other"));
+	}
+}
+
+#[test]
+fn mock_pagination_preserves_opaque_links_and_rejects_foreign_urls_and_redirects() {
+	let _network = MOCK_NETWORK.lock().unwrap();
+	let mut first = MockResponse::json(serde_json::json!([account_json("server-local-id", "alice@example.org")]));
+	first.headers = "Link: <{origin}/api/v1/accounts/me/following?cursor=opaque%2Bvalue>; rel=\"next\"\r\n".into();
+	let (base, requests) = server(vec![first, MockResponse::json(serde_json::json!([]))]);
+	let client = MastodonClient::for_autocomplete(base.clone()).unwrap();
+	let page = client.autocomplete_page("test-token", "me", true, None).unwrap();
+	assert_eq!(page.accounts[0].id, "server-local-id");
+	assert!(page.next.as_ref().unwrap().ends_with("cursor=opaque%2Bvalue"));
+	assert!(client.autocomplete_page("test-token", "me", true, page.next.as_deref()).unwrap().next.is_none());
+	let first = requests.recv_timeout(Duration::from_secs(2)).unwrap();
+	assert!(first.to_lowercase().contains("authorization: bearer test-token"));
+	assert!(requests.recv_timeout(Duration::from_secs(2)).unwrap().contains("cursor=opaque%2Bvalue"));
+	assert!(
+		client
+			.autocomplete_page("test-token", "me", true, Some("https://evil.invalid/api/v1/accounts/me/following"))
+			.is_err()
+	);
+	assert!(
+		client
+			.autocomplete_page(
+				"test-token",
+				"me",
+				true,
+				Some(base.join("api/v1/accounts/other/following").unwrap().as_str())
+			)
+			.is_err()
+	);
+	let mut redirect = MockResponse::json(serde_json::json!([]));
+	redirect.status = 302;
+	redirect.headers = "Location: https://evil.invalid/\r\n".into();
+	let (base, _) = server(vec![redirect]);
+	assert!(MastodonClient::for_autocomplete(base).unwrap().autocomplete_page("test-token", "me", true, None).is_err());
+}
+
+#[test]
+fn mock_rate_observations_are_shared_and_respect_both_deadlines() {
+	let _network = MOCK_NETWORK.lock().unwrap();
+	let mut response = MockResponse::json(serde_json::json!([]));
+	response.status = 429;
+	response.headers = format!(
+		"Retry-After: 60\r\nX-RateLimit-Limit: 100\r\nX-RateLimit-Remaining: 0\r\nX-RateLimit-Reset: {}\r\n",
+		(chrono::Utc::now() + chrono::Duration::seconds(90)).to_rfc3339()
+	);
+	let (base, _) = server(vec![response]);
+	let client = MastodonClient::new(base.clone()).unwrap();
+	let error = client.get_following_page("token", "me", None).err().unwrap();
+	assert_eq!(
+		error.downcast_ref::<reqwest::Error>().and_then(reqwest::Error::status).map(|s| s.as_u16()),
+		Some(429),
+		"Expected mock server response: {error:#}"
+	);
+	let now = Instant::now();
+	let deadline = rate::defer_until(&base.origin().ascii_serialization(), now).unwrap();
+	assert!(deadline > now + Duration::from_secs(85));
+	assert!(rate::defer_until(&base.origin().ascii_serialization(), now + Duration::from_secs(95)).is_none());
+	for (limit, remaining, defer) in [(5, 1, true), (5, 5, false), (1, 1, false), (1000, 100, true), (1000, 101, false)]
+	{
+		let mut response = MockResponse::json(serde_json::json!([]));
+		response.headers = format!(
+			"X-RateLimit-Limit: {limit}\r\nX-RateLimit-Remaining: {remaining}\r\nX-RateLimit-Reset: {}\r\n",
+			(chrono::Utc::now() + chrono::Duration::seconds(60)).to_rfc3339()
+		);
+		let (base, _) = server(vec![response]);
+		MastodonClient::new(base.clone()).unwrap().get_following_page("token", "me", None).unwrap();
+		assert_eq!(rate::defer_until(&base.origin().ascii_serialization(), Instant::now()).is_some(), defer);
+	}
+	assert!((30..=33).contains(&rate::backoff(0).as_secs()));
+	assert_eq!(rate::backoff(100).as_secs(), 300);
+}
+
+#[test]
+fn shutdown_during_inflight_fetch_does_not_wait_for_network_or_backoff() {
+	let _network = MOCK_NETWORK.lock().unwrap();
+	let dir = TestDirectory::new();
+	let mut response = MockResponse::json(serde_json::json!([]));
+	response.delay = Duration::from_secs(2);
+	let (base, requests) = server(vec![response]);
+	let service = Service::start(dir.cache(), HashSet::from(["a".into()]), UiWaker::silent());
+	service.activate("a".into(), base, "secret".into(), "me".into());
+	requests.recv_timeout(Duration::from_secs(5)).unwrap();
+	let started = Instant::now();
+	service.shutdown();
+	wait_for_shutdown(&service).unwrap();
+	assert!(started.elapsed() < Duration::from_secs(1));
+}
+
+#[test]
+fn successful_interaction_survives_dropped_ui_receiver_and_account_switch() {
+	let _network = MOCK_NETWORK.lock().unwrap();
+	let dir = TestDirectory::new();
+	let status = serde_json::json!({"id":"post","content":"hello","created_at":"2026-01-01T00:00:00Z","account":account_json("local-author", "alice@example.org"),"spoiler_text":"","visibility":"public","reblogs_count":0,"favourites_count":1,"replies_count":0});
+	let (base, requests) = server(vec![MockResponse::json(status)]);
+	let service = Service::start(dir.cache(), HashSet::from(["a".into(), "b".into()]), UiWaker::silent());
+	let handle =
+		crate::network::start_network(base, "token".into(), UiWaker::silent(), service.session("a".into())).unwrap();
+	handle.send(crate::network::NetworkCommand::Favorite { status_id: "post".into() });
+	drop(handle);
+	service.published.lock().unwrap().active = Some("b".into());
+	requests.recv_timeout(Duration::from_secs(3)).unwrap();
+	let deadline = Instant::now() + Duration::from_secs(3);
+	while service.session("a".into()).snapshot().entries.is_empty() {
+		assert!(Instant::now() < deadline);
+		thread::sleep(Duration::from_millis(5));
+	}
+	assert_eq!(service.session("a".into()).snapshot().entries[0].1.id, "local-author");
+	assert!(service.session("b".into()).snapshot().entries.is_empty());
+	service.shutdown();
+	wait_for_shutdown(&service).unwrap();
+}
+
+#[test]
+fn background_total_timeout_is_bounded() {
+	let _network = MOCK_NETWORK.lock().unwrap();
+	let mut response = MockResponse::json(serde_json::json!([]));
+	response.delay = Duration::from_millis(300);
+	let (base, _) = server(vec![response]);
+	let client =
+		MastodonClient::autocomplete_with_timeouts(base, Duration::from_millis(50), Duration::from_millis(100))
+			.unwrap();
+	let started = Instant::now();
+	let error = client.autocomplete_page("token", "me", true, None).err().unwrap();
+	assert!(error.downcast_ref::<reqwest::Error>().is_some_and(reqwest::Error::is_timeout));
+	assert!(started.elapsed() < Duration::from_secs(1));
+}
+
+#[test]
+fn foreground_priority_refresh_deadline_and_credentials_generation() {
+	let (mut c, jobs) = model();
+	let now = Instant::now();
+	c.next_fetch = now;
+	c.schedule(now, 100, true);
+	assert!(jobs.try_recv().is_err());
+	c.schedule(now + Duration::from_secs(1), 101, false);
+	let old = jobs.try_recv().unwrap();
+	let mut credentials = c.credentials["a"].clone();
+	credentials.token = "replacement-token".into();
+	c.command(Command::Activate("a".into(), credentials));
+	page(&mut c, old, vec![entry("1", "@stale@example.org")], None);
+	assert!(c.accounts["a"].entries.is_empty());
+	let account = c.accounts.get_mut("a").unwrap();
+	account.sources.iter_mut().for_each(|source| source.done = true);
+	account.last_complete = Some(100);
+	account.entries.insert("1".into(), entry("1", "@alice@example.org"));
+	c.schedule(now + Duration::from_secs(2), 200, false);
+	assert!(jobs.try_recv().is_err());
+	c.schedule(now + Duration::from_secs(86400), 86500, false);
+	assert_eq!(jobs.try_recv().unwrap().source, 0);
+	assert_eq!(c.accounts["a"].entries.len(), 1, "Refresh must preserve saved data");
+}
+
+#[test]
+fn rejected_checkpoint_restarts_only_failed_source_and_retains_data() {
+	let (mut c, _) = model();
+	let request = job(&c, "a", 0);
+	page(
+		&mut c,
+		request,
+		vec![entry("1", "@alice@example.org")],
+		Some("https://test.invalid/api/v1/accounts/me/following?cursor=expired"),
+	);
+	let request = job(&c, "a", 0);
+	c.command(Command::Fetched(request, Err("expired cursor".into()), Some(400)));
+	assert!(c.accounts["a"].sources[0].next.is_none());
+	assert!(c.accounts["a"].sources[0].retry.is_some());
+	assert!(!c.accounts["a"].sources[1].done);
+	assert_eq!(c.accounts["a"].entries.len(), 1);
+}

--- a/src/autocomplete/text.rs
+++ b/src/autocomplete/text.rs
@@ -1,0 +1,149 @@
+//! Mention editing uses UTF-8 byte offsets; native positions are adapted at the UI boundary.
+use std::ops::Range;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct MentionEdit {
+	pub range: Range<usize>,
+	pub filter: String,
+	pub leading_space: bool,
+}
+
+fn opening(c: char) -> bool {
+	c.is_whitespace() || "([{\"',:;!?".contains(c)
+}
+
+fn closing(c: char) -> bool {
+	")]}\"',:;!?.".contains(c)
+}
+
+fn component(c: char, domain: bool) -> bool {
+	c.is_alphanumeric() || if domain { c == '-' } else { c == '_' }
+}
+
+fn mention_end(text: &str, start: usize) -> usize {
+	let mut end = start + 1;
+	let mut domain = false;
+	let mut previous = false;
+	let mut chars = text[end..].char_indices().peekable();
+	while let Some((offset, c)) = chars.next() {
+		if c == '@' && !domain {
+			domain = true;
+			previous = false;
+		} else if component(c, domain) {
+			previous = true;
+		} else if c == '.' && previous && chars.peek().is_some_and(|(_, next)| component(*next, domain)) {
+			previous = false;
+		} else {
+			break;
+		}
+		end = start + 1 + offset + c.len_utf8();
+	}
+	end
+}
+
+pub fn prepare(text: &str, caret: usize, selection: Range<usize>) -> MentionEdit {
+	assert!(text.is_char_boundary(caret));
+	if !selection.is_empty() {
+		let selected = &text[selection.clone()];
+		let filter = if selected.starts_with('@') && mention_end(selected, 0) == selected.len() {
+			selected.to_owned()
+		} else {
+			String::new()
+		};
+		return MentionEdit { range: selection, filter, leading_space: false };
+	}
+	// Scan only the token touching the caret, never an earlier whitespace-delimited token.
+	let token_start =
+		text[..caret].rfind(char::is_whitespace).map_or(0, |i| i + text[i..].chars().next().unwrap().len_utf8());
+	for (offset, c) in text[token_start..caret].char_indices() {
+		let start = token_start + offset;
+		let prefix = &text[token_start..start];
+		if prefix.contains("://") || prefix.starts_with("mailto:") || prefix.starts_with("www.") {
+			break;
+		}
+		if c == '@' && (start == 0 || text[..start].chars().next_back().is_some_and(opening)) {
+			let end = mention_end(text, start);
+			if caret <= end {
+				return MentionEdit { range: start..end, filter: text[start..caret].to_owned(), leading_space: false };
+			}
+		}
+	}
+	let end = text[caret..].find(char::is_whitespace).map_or(text.len(), |i| caret + i);
+	let word_end = token_start + text[token_start..end].trim_end_matches(closing).len();
+	if caret > token_start && caret <= word_end {
+		return MentionEdit { range: word_end..word_end, filter: String::new(), leading_space: true };
+	}
+	MentionEdit { range: caret..caret, filter: String::new(), leading_space: false }
+}
+
+impl MentionEdit {
+	/// Replacement and following space are passed to the native control as one undoable edit.
+	pub fn replacement(&self, original: &str, address: &str) -> (String, usize) {
+		let mut replacement = if self.leading_space { format!(" {address}") } else { address.to_owned() };
+		let caret = self.range.start + replacement.len();
+		if original[self.range.end..].chars().next().is_some_and(|c| !c.is_whitespace() && !closing(c)) {
+			replacement.push(' ');
+		}
+		(replacement, caret)
+	}
+}
+
+/// wxMSW multiline EDIT positions count CRLF as two UTF-16 units, even though `GetValue` returns LF.
+pub fn native_to_byte(text: &str, position: usize, crlf: bool) -> usize {
+	let mut native = 0;
+	for (byte, c) in text.char_indices() {
+		let width = c.len_utf16() + usize::from(crlf && c == '\n');
+		if native + width > position {
+			return byte;
+		}
+		native += width;
+	}
+	text.len()
+}
+
+pub fn byte_to_native(text: &str, byte: usize, crlf: bool) -> usize {
+	text[..byte].chars().map(|c| c.len_utf16() + usize::from(crlf && c == '\n')).sum()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	#[test]
+	fn design_examples() {
+		for (input, filter, output) in [
+			("Hello @al|", "@al", "Hello @alice@example.org|"),
+			("Hello @al|ice", "@al", "Hello @alice@example.org|"),
+			("Hello @|", "@", "Hello @alice@example.org|"),
+			("@alice@exa|mple.net", "@alice@exa", "@alice@example.org|"),
+			("(@al|), thanks", "@al", "(@alice@example.org|), thanks"),
+			("Hello @bob, how ar|e", "", "Hello @bob, how are @alice@example.org|"),
+			("hel|lo, friend", "", "hello @alice@example.org|, friend"),
+			("Hello |world", "", "Hello @alice@example.org| world"),
+			("mail a@exa|mple.org", "", "mail a@example.org @alice@example.org|"),
+			("https://a/@al|ice", "", "https://a/@alice @alice@example.org|"),
+			("https://a/?@al|ice", "", "https://a/?@alice @alice@example.org|"),
+			("mailto:@al|ice", "", "mailto:@alice @alice@example.org|"),
+			("😀\n@a|.", "@a", "😀\n@alice@example.org|."),
+		] {
+			let caret = input.find('|').unwrap();
+			let mut text = input.replace('|', "");
+			let edit = prepare(&text, caret, caret..caret);
+			assert_eq!(edit.filter, filter, "{input}");
+			let (replacement, new_caret) = edit.replacement(&text, "@alice@example.org");
+			text.replace_range(edit.range, &replacement);
+			text.insert(new_caret, '|');
+			assert_eq!(text, output, "{input}");
+		}
+	}
+	#[test]
+	fn selections_and_native_positions() {
+		assert_eq!(prepare("hi @alice!", 6, 3..6).filter, "@al");
+		assert_eq!(prepare("hi @alice!", 6, 0..6).filter, "");
+		for crlf in [true, false] {
+			let text = "😀 hi\n@é\nend";
+			for byte in text.char_indices().map(|(i, _)| i).chain([text.len()]) {
+				assert_eq!(native_to_byte(text, byte_to_native(text, byte, crlf), crlf), byte);
+			}
+		}
+	}
+}

--- a/src/autocomplete/timing.rs
+++ b/src/autocomplete/timing.rs
@@ -1,0 +1,131 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BuildTiming {
+	pub started_at: i64,
+	pub completed_at: Option<i64>,
+	pub started_on_resume: bool,
+	#[serde(default)]
+	pub requests: Option<RequestCount>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RequestCount {
+	pub attempts: u64,
+	pub complete: bool,
+}
+
+impl BuildTiming {
+	pub const fn new(started_at: i64, started_on_resume: bool) -> Self {
+		Self {
+			started_at,
+			completed_at: None,
+			started_on_resume,
+			requests: Some(RequestCount { attempts: 0, complete: !started_on_resume }),
+		}
+	}
+
+	pub fn record_request(&mut self) {
+		let requests = self.requests.get_or_insert(RequestCount { attempts: 0, complete: false });
+		requests.attempts = requests.attempts.saturating_add(1);
+	}
+
+	pub fn start_message(&self, account: &str) -> String {
+		format!(
+			"{} Autocomplete cache build {} for account {account:?}.{}",
+			timestamp(self.started_at),
+			if self.started_on_resume { "resumed" } else { "started" },
+			if self.started_on_resume { " Original start time is unknown; timing begins at this resume." } else { "" }
+		)
+	}
+
+	pub fn finish(&mut self, account: &str, completed_at: i64) -> Option<String> {
+		if self.completed_at.is_some() {
+			return None;
+		}
+		self.completed_at = Some(completed_at);
+		let elapsed = completed_at.saturating_sub(self.started_at);
+		let duration = if elapsed < 0 {
+			"duration unavailable because the system clock moved backwards".into()
+		} else {
+			format!(
+				"{} {}",
+				if self.started_on_resume { "time since resume:" } else { "total duration:" },
+				human_duration(elapsed.unsigned_abs())
+			)
+		};
+		let requests = self.requests.as_ref().map_or_else(
+			|| "API request count unavailable".into(),
+			|requests| {
+				if requests.complete {
+					format!("API requests: {}", requests.attempts)
+				} else {
+					format!("API requests since tracking began: {} (earlier requests unknown)", requests.attempts)
+				}
+			},
+		);
+		Some(format!(
+			"{} Autocomplete cache build completed for account {account:?}; started {}; {duration} (elapsed time includes pauses and retries); {requests} (includes failed attempts, retries, and relationship confirmations).",
+			timestamp(completed_at),
+			timestamp(self.started_at)
+		))
+	}
+}
+
+fn timestamp(unix: i64) -> String {
+	chrono::DateTime::from_timestamp(unix, 0).map_or_else(
+		|| format!("Unix timestamp {unix}"),
+		|time| time.with_timezone(&chrono::Local).to_rfc3339_opts(chrono::SecondsFormat::Secs, false),
+	)
+}
+
+fn human_duration(mut seconds: u64) -> String {
+	let mut parts = Vec::new();
+	for (unit, size) in [("day", 86400), ("hour", 3600), ("minute", 60), ("second", 1)] {
+		let amount = seconds / size;
+		seconds %= size;
+		if amount > 0 {
+			parts.push(format!("{amount} {unit}{}", if amount == 1 { "" } else { "s" }));
+		}
+	}
+	if parts.is_empty() { "less than 1 second".into() } else { parts.join(" ") }
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn readable_durations_and_clock_changes() {
+		for (seconds, expected) in [
+			(0, "less than 1 second"),
+			(1, "1 second"),
+			(134, "2 minutes 14 seconds"),
+			(3600, "1 hour"),
+			(90061, "1 day 1 hour 1 minute 1 second"),
+		] {
+			assert_eq!(human_duration(seconds), expected);
+		}
+		let mut timing = BuildTiming::new(200, false);
+		assert!(timing.finish("a", 199).unwrap().contains("system clock moved backwards"));
+		assert!(timing.finish("a", 201).is_none());
+	}
+
+	#[test]
+	fn older_timing_records_cannot_claim_a_full_request_count() {
+		let mut timing: BuildTiming = serde_json::from_value(serde_json::json!({
+			"started_at": 100, "completed_at": null, "started_on_resume": false
+		}))
+		.unwrap();
+		timing.record_request();
+		let saved = serde_json::to_vec(&timing).unwrap();
+		let mut timing: BuildTiming = serde_json::from_slice(&saved).unwrap();
+		timing.record_request();
+		assert!(
+			timing
+				.finish("a", 234)
+				.unwrap()
+				.contains("API requests since tracking began: 2 (earlier requests unknown)")
+		);
+	}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 
 mod accounts;
 mod auth;
+mod autocomplete;
 mod config;
 mod html;
 mod mastodon;
@@ -17,6 +18,8 @@ mod text;
 mod timeline;
 mod ui;
 mod ui_wake;
+
+const ID_AUTOCOMPLETE_WAKE: i32 = 29_900;
 
 use std::{
 	cell::Cell,
@@ -72,7 +75,7 @@ pub struct ContextMenuState {
 
 pub(crate) enum PostOperation {
 	NewPost,
-	Reply { in_reply_to_id: String },
+	Reply { in_reply_to_id: String, foreign_url: Option<String> },
 	Edit { status_id: String },
 	Quote { quoted_status_id: String },
 }
@@ -84,6 +87,7 @@ pub(crate) struct PendingPost {
 }
 
 pub(crate) struct AppState {
+	pub(crate) autocomplete: autocomplete::Service,
 	pub(crate) config: Config,
 	pub(crate) timeline_manager: TimelineManager,
 	pub(crate) account_timelines: HashMap<String, TimelineManager>,
@@ -116,8 +120,14 @@ pub(crate) struct AppState {
 }
 
 impl AppState {
-	fn new(config: Config, ui_waker: UiWaker, instance_checker: Option<SingleInstanceChecker>) -> Self {
+	fn new(
+		config: Config,
+		ui_waker: UiWaker,
+		instance_checker: Option<SingleInstanceChecker>,
+		autocomplete: autocomplete::Service,
+	) -> Self {
 		Self {
+			autocomplete,
 			config,
 			timeline_manager: TimelineManager::new(),
 			account_timelines: HashMap::new(),
@@ -155,6 +165,10 @@ impl AppState {
 			.active_account_id
 			.as_ref()
 			.map_or_else(|| self.config.accounts.first(), |id| self.config.accounts.iter().find(|a| &a.id == id))
+	}
+
+	pub(crate) fn autocomplete_session(&self) -> Option<autocomplete::Session> {
+		self.active_account().map(|account| self.autocomplete.session(account.id.clone()))
 	}
 
 	pub(crate) fn active_account_mut(&mut self) -> Option<&mut config::Account> {
@@ -229,17 +243,20 @@ fn main() {
 		let autoload_mode = Rc::new(Cell::new(config.autoload));
 		let sort_order_cell = Rc::new(Cell::new(config.sort_order));
 		let shortcuts_cell = Rc::new(std::cell::RefCell::new(config.shortcuts.clone()));
-		let mut state = AppState::new(config, ui_waker.clone(), instance_checker);
+		let autocomplete_waker = UiWaker::with_event(frame, ui_alive.clone(), ID_AUTOCOMPLETE_WAKE);
+		let autocomplete = autocomplete::Service::start(
+			config::config_dir().join("autocomplete-cache.json"),
+			config.accounts.iter().map(|a| a.id.clone()).collect(),
+			autocomplete_waker.clone(),
+		);
+		let mut state = AppState::new(config, ui_waker.clone(), instance_checker, autocomplete.clone());
 		let mc = MediaCtrl::builder(&frame).with_size(Size::new(0, 0)).build();
 		let sound_path = get_sound_path();
 		if sound_path.exists() {
 			mc.load(&sound_path.to_string_lossy());
 		}
 		state.media_ctrl = Some(mc);
-		if state.config.accounts.is_empty() && !start_add_account_flow(&frame, &ui_tx, &mut state) {
-			frame.close(true);
-			return;
-		}
+		let close_after_init = state.config.accounts.is_empty() && !start_add_account_flow(&frame, &ui_tx, &mut state);
 		if let Some(mb) = frame.get_menu_bar() {
 			update_menu_labels(&mb, &state);
 		}
@@ -247,6 +264,30 @@ fn main() {
 		let app_shell = Rc::new(ui::app_shell::install_app_shell(&frame, ui_tx.clone(), &state.config.hotkey));
 		let app_shell_close = app_shell.clone();
 		state.app_shell = Some(app_shell);
+		let autocomplete_events = autocomplete.clone();
+		let autocomplete_close_sent = Cell::new(false);
+		let autocomplete_ui_tx = ui_tx.clone();
+		let autocomplete_initial_wake = autocomplete_waker.clone();
+		frame.bind_with_id_internal(EventType::MENU, ID_AUTOCOMPLETE_WAKE, move |_| {
+			autocomplete_waker.reset();
+			ui::dialogs::autocomplete_picker::dispatch_update();
+			if let Some(result) = autocomplete_events.shutdown_result()
+				&& !autocomplete_close_sent.replace(true)
+			{
+				if let Err(error) = result {
+					ui::dialogs::show_error(
+						&frame,
+						&anyhow::anyhow!("Autocomplete could not save all cache or log updates: {error}"),
+					);
+				}
+				frame.show(false);
+				app_shell_close.cleanup();
+				let _ = autocomplete_ui_tx.send(UiCommand::AppClosing);
+			}
+		});
+		// Startup prompts may have drained posted events before the handlers were installed.
+		autocomplete_initial_wake.reset();
+		autocomplete_initial_wake.wake();
 
 		if state.config.check_for_updates_on_startup {
 			crate::ui::update_check::run_update_check(frame, true);
@@ -261,7 +302,8 @@ fn main() {
 		let timeline_list_wake = timeline_list;
 		let mut state = state;
 		let context_menu_state_for_handlers = state.context_menu_state.clone();
-		let ui_waker_handler = ui_waker.clone();
+		let ui_waker_initial = ui_waker.clone();
+		let ui_waker_handler = ui_waker;
 		let quick_action_keys_drain = quick_action_keys_enabled.clone();
 		let autoload_drain = autoload_mode.clone();
 		let sort_order_drain = sort_order_cell.clone();
@@ -367,24 +409,19 @@ fn main() {
 			shortcuts_cell,
 		);
 		let shutdown_close = is_shutting_down;
-		let frame_close = frame;
-		let ui_tx_close = ui_tx.clone();
-		let ui_waker_close = ui_waker;
 		frame.on_close(move |event| {
-			if shutdown_close.get() {
-				event.skip(true); // Actually close
-			} else {
-				shutdown_close.set(true);
-				let _ = ui_tx_close.send(UiCommand::AppClosing);
-				ui_waker_close.wake();
-				// Hide the window and clean up the tray icon before destruction begins,
-				// so the screen reader doesn't announce the window during teardown.
-				frame_close.show(false);
-				app_shell_close.cleanup();
-				event.skip(false); // Wait for AppClosing command to be processed
+			if !shutdown_close.replace(true) {
+				autocomplete.shutdown();
 			}
+			event.skip(false); // Repeated closes cannot bypass the final cache save.
 		});
-		frame.show(true);
-		frame.centre();
+		ui_waker_initial.reset();
+		ui_waker_initial.wake();
+		if close_after_init {
+			frame.close(true);
+		} else {
+			frame.show(true);
+			frame.centre();
+		}
 	});
 }

--- a/src/mastodon.rs
+++ b/src/mastodon.rs
@@ -14,7 +14,7 @@ mod tag;
 mod time;
 
 pub use account::{Account, Relationship, Source};
-pub use client::{AppCredentials, DEFAULT_SCOPES, MastodonClient};
+pub use client::{AppCredentials, DEFAULT_SCOPES, InvalidAccountPagination, MastodonClient};
 pub use filter::{Filter, FilterAction, FilterContext, FilterKeyword, FilterResult};
 pub use instance::InstanceInfo;
 pub use list::List;

--- a/src/mastodon/account.rs
+++ b/src/mastodon/account.rs
@@ -56,6 +56,10 @@ pub struct Account {
 	#[serde(default)]
 	pub discoverable: Option<bool>,
 	#[serde(default)]
+	pub moved: Option<Box<Account>>,
+	#[serde(default)]
+	pub suspended: Option<bool>,
+	#[serde(default)]
 	pub source: Option<Source>,
 }
 

--- a/src/mastodon/client.rs
+++ b/src/mastodon/client.rs
@@ -10,6 +10,7 @@ mod statuses;
 mod tags;
 mod timelines;
 
+pub use accounts::InvalidAccountPagination;
 use anyhow::{Context, Result};
 use reqwest::{
 	Url,
@@ -32,6 +33,32 @@ pub struct AppCredentials {
 }
 
 impl MastodonClient {
+	pub fn for_autocomplete(base_url: Url) -> Result<Self> {
+		Self::autocomplete_with_timeouts(
+			base_url,
+			std::time::Duration::from_secs(5),
+			std::time::Duration::from_secs(15),
+		)
+	}
+
+	pub fn autocomplete_with_timeouts(
+		base_url: Url,
+		connect: std::time::Duration,
+		total: std::time::Duration,
+	) -> Result<Self> {
+		let http = Client::builder()
+			.user_agent("Fedra/0.1")
+			.connect_timeout(connect)
+			.timeout(total)
+			.redirect(reqwest::redirect::Policy::none())
+			.build()?;
+		Ok(Self { base_url, http })
+	}
+
+	fn observed(response: Response) -> Response {
+		crate::autocomplete::rate::observe(&response);
+		response
+	}
 	pub fn new(base_url: Url) -> Result<Self> {
 		let http = Client::builder().user_agent("Fedra/0.1").build().context("Failed to create HTTP client")?;
 		Ok(Self { base_url, http })
@@ -47,9 +74,8 @@ impl MastodonClient {
 	/// `what` names the operation as a verb phrase, e.g. `"favorite status"`, and is
 	/// used to build the error context for each stage of the request.
 	fn send_json<T: DeserializeOwned>(request: RequestBuilder, what: &str) -> Result<T> {
-		let response = request
-			.send()
-			.with_context(|| format!("Failed to {what}"))?
+		let _activity = crate::autocomplete::rate::foreground();
+		let response = Self::observed(request.send().with_context(|| format!("Failed to {what}"))?)
 			.error_for_status()
 			.with_context(|| format!("Instance rejected request to {what}"))?;
 		response.json().with_context(|| format!("Invalid response while trying to {what}"))
@@ -57,9 +83,8 @@ impl MastodonClient {
 
 	/// Like [`Self::send_json`], but also returns the `max_id` of the next page, if any.
 	fn send_json_paged<T: DeserializeOwned>(request: RequestBuilder, what: &str) -> Result<(T, Option<String>)> {
-		let response = request
-			.send()
-			.with_context(|| format!("Failed to {what}"))?
+		let _activity = crate::autocomplete::rate::foreground();
+		let response = Self::observed(request.send().with_context(|| format!("Failed to {what}"))?)
 			.error_for_status()
 			.with_context(|| format!("Instance rejected request to {what}"))?;
 		let next_max_id = Self::next_max_id(&response);
@@ -69,9 +94,8 @@ impl MastodonClient {
 
 	/// Sends `request` and discards the body, for endpoints that return no content.
 	fn send_empty(request: RequestBuilder, what: &str) -> Result<()> {
-		request
-			.send()
-			.with_context(|| format!("Failed to {what}"))?
+		let _activity = crate::autocomplete::rate::foreground();
+		Self::observed(request.send().with_context(|| format!("Failed to {what}"))?)
 			.error_for_status()
 			.with_context(|| format!("Instance rejected request to {what}"))?;
 		Ok(())

--- a/src/mastodon/client/accounts.rs
+++ b/src/mastodon/client/accounts.rs
@@ -5,7 +5,75 @@ use reqwest::{Url, blocking::multipart};
 
 use crate::mastodon::{Account, MastodonClient, Relationship};
 
+pub struct AccountPage {
+	pub accounts: Vec<Account>,
+	pub next: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct InvalidAccountPagination;
+impl std::fmt::Display for InvalidAccountPagination {
+	fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str("Unsafe or invalid account pagination link")
+	}
+}
+impl std::error::Error for InvalidAccountPagination {}
+
+fn validate_page_url(base: &Url, expected: &Url, url: &Url) -> Result<()> {
+	anyhow::ensure!(
+		url.origin() == base.origin()
+			&& url.path() == expected.path()
+			&& url.username().is_empty()
+			&& url.password().is_none()
+			&& url.fragment().is_none(),
+		InvalidAccountPagination
+	);
+	Ok(())
+}
+
 impl MastodonClient {
+	#[cfg(test)]
+	pub fn autocomplete_page(&self, token: &str, id: &str, following: bool, next: Option<&str>) -> Result<AccountPage> {
+		self.autocomplete_page_observed(token, id, following, next, || {})
+	}
+
+	pub fn autocomplete_page_observed(
+		&self,
+		token: &str,
+		id: &str,
+		following: bool,
+		next: Option<&str>,
+		request_started: impl FnOnce(),
+	) -> Result<AccountPage> {
+		let source = if following { "following" } else { "followers" };
+		let expected = self.base_url.join(&format!("api/v1/accounts/{id}/{source}"))?;
+		let mut url = next.map_or_else(|| Ok(expected.clone()), Url::parse).map_err(|_| InvalidAccountPagination)?;
+		validate_page_url(&self.base_url, &expected, &url)?;
+		if next.is_none() {
+			url.query_pairs_mut().append_pair("limit", "80");
+		}
+		let request = self.http.get(url).bearer_auth(token);
+		request_started();
+		let response = Self::observed(request.send()?).error_for_status()?;
+		anyhow::ensure!(response.status().is_success(), "Unexpected account-list response status");
+		let mut next = None;
+		for header in response.headers().get_all("link") {
+			for link in header.to_str()?.split(',') {
+				let mut parts = link.split(';');
+				let address = parts.next().unwrap_or_default().trim().trim_start_matches('<').trim_end_matches('>');
+				if parts.any(|p| {
+					p.trim()
+						.strip_prefix("rel=")
+						.is_some_and(|rel| rel.trim_matches('"').split_whitespace().any(|r| r == "next"))
+				}) {
+					let target = response.url().join(address)?;
+					validate_page_url(&self.base_url, &expected, &target)?;
+					next = Some(target.to_string());
+				}
+			}
+		}
+		Ok(AccountPage { accounts: response.json()?, next })
+	}
 	pub fn get_account(&self, access_token: &str, account_id: &str) -> Result<Account> {
 		let url = self.base_url.join(&format!("api/v1/accounts/{account_id}"))?;
 		self.get_json(access_token, url, "fetch account")
@@ -35,7 +103,7 @@ impl MastodonClient {
 		if let Some(token) = access_token {
 			req = req.bearer_auth(token);
 		}
-		let response = req.send()?.error_for_status()?;
+		let response = Self::observed(req.send()?).error_for_status()?;
 		let next_max_id = Self::next_max_id(&response);
 		let accounts: Vec<Account> = response.json()?;
 		Ok((accounts, next_max_id))
@@ -109,6 +177,15 @@ impl MastodonClient {
 	}
 
 	pub fn get_relationships(&self, access_token: &str, account_ids: &[String]) -> Result<Vec<Relationship>> {
+		self.get_relationships_observed(access_token, account_ids, || {})
+	}
+
+	pub fn get_relationships_observed(
+		&self,
+		access_token: &str,
+		account_ids: &[String],
+		request_started: impl FnOnce(),
+	) -> Result<Vec<Relationship>> {
 		let mut url = self.base_url.join("api/v1/accounts/relationships")?;
 		{
 			let mut query = url.query_pairs_mut();
@@ -116,6 +193,7 @@ impl MastodonClient {
 				query.append_pair("id[]", id);
 			}
 		}
+		request_started();
 		self.get_json(access_token, url, "fetch relationships")
 	}
 

--- a/src/mastodon/client/statuses.rs
+++ b/src/mastodon/client/statuses.rs
@@ -77,6 +77,7 @@ impl MastodonClient {
 		}
 		let response =
 			self.http.post(url).bearer_auth(access_token).form(&params).send().context("Failed to post status")?;
+		let response = Self::observed(response);
 		let status = response.status();
 		if !status.is_success() {
 			let body = response.text().unwrap_or_default();
@@ -111,6 +112,7 @@ impl MastodonClient {
 		}
 		let response =
 			self.http.post(url).bearer_auth(access_token).multipart(form).send().context("Failed to upload media")?;
+		let response = Self::observed(response);
 		let status = response.status();
 		let response = response.error_for_status().context("Instance rejected media upload")?;
 		let payload: MediaResponse = response.json().context("Invalid media upload response")?;
@@ -132,6 +134,7 @@ impl MastodonClient {
 				.bearer_auth(access_token)
 				.send()
 				.context("Failed to check media processing status")?;
+			let response = Self::observed(response);
 			match response.status() {
 				StatusCode::OK => return Ok(()),
 				StatusCode::PARTIAL_CONTENT => {}

--- a/src/network.rs
+++ b/src/network.rs
@@ -35,6 +35,7 @@ pub enum RelationshipAction {
 
 #[derive(Debug, Clone)]
 pub struct PostData {
+	pub interaction_author: Option<Account>,
 	pub content: String,
 	pub visibility: String,
 	pub sensitive: bool,
@@ -123,6 +124,7 @@ pub enum NetworkCommand {
 	},
 	Reply {
 		in_reply_to_id: String,
+		interaction_author: Option<Account>,
 		content: String,
 		visibility: String,
 		sensitive: bool,
@@ -141,12 +143,12 @@ pub enum NetworkCommand {
 	},
 	FollowAccount {
 		account_id: String,
+		target_acct: String,
 		target_name: String,
 		reblogs: bool,
 		action: RelationshipAction,
 	},
 	ToggleFollow {
-		account_id: Option<String>,
 		acct: String,
 		target_name: String,
 	},
@@ -564,9 +566,23 @@ fn edit_with_media(
 }
 
 pub struct NetworkHandle {
-	pub command_tx: Sender<NetworkCommand>,
+	pub command_tx: NetworkSender,
 	response_rx: Receiver<NetworkResponse>,
 	_thread: JoinHandle<()>,
+}
+
+#[derive(Clone)]
+pub struct NetworkSender(Sender<QueuedCommand>);
+struct QueuedCommand {
+	command: NetworkCommand,
+	_foreground: crate::autocomplete::rate::ForegroundGuard,
+}
+impl NetworkSender {
+	pub fn send(&self, command: NetworkCommand) -> Result<(), Box<mpsc::SendError<NetworkCommand>>> {
+		self.0
+			.send(QueuedCommand { command, _foreground: crate::autocomplete::rate::foreground() })
+			.map_err(|error| Box::new(mpsc::SendError(error.0.command)))
+	}
 }
 
 impl NetworkHandle {
@@ -597,19 +613,68 @@ impl Drop for NetworkHandle {
 	}
 }
 
-pub fn start_network(base_url: Url, access_token: String, ui_waker: UiWaker) -> Result<NetworkHandle> {
+pub fn start_network(
+	base_url: Url,
+	access_token: String,
+	ui_waker: UiWaker,
+	autocomplete: crate::autocomplete::Session,
+) -> Result<NetworkHandle> {
 	let client = MastodonClient::new(base_url)?;
 	let (cmd_tx, cmd_rx) = mpsc::channel();
 	let (resp_tx, resp_rx) = mpsc::channel();
 	let thread = thread::spawn(move || {
-		network_loop(&client, &access_token, &cmd_rx, &resp_tx, &ui_waker);
+		network_loop(&client, &access_token, &cmd_rx, &resp_tx, &ui_waker, &autocomplete);
 	});
-	Ok(NetworkHandle { command_tx: cmd_tx, response_rx: resp_rx, _thread: thread })
+	Ok(NetworkHandle { command_tx: NetworkSender(cmd_tx), response_rx: resp_rx, _thread: thread })
 }
 
 fn send_response(responses: &Sender<NetworkResponse>, ui_waker: &UiWaker, response: NetworkResponse) {
 	let _ = responses.send(response);
 	ui_waker.wake();
+}
+
+fn capture_publication(
+	session: &crate::autocomplete::Session,
+	base: &Url,
+	result: &Result<PostSubmission>,
+	author: Option<&Account>,
+) {
+	if matches!(result, Ok(PostSubmission::Published(_)))
+		&& let Some(author) = author
+	{
+		session.interaction(crate::autocomplete::Entry::from_account(author, base));
+	}
+}
+
+/// Runs in the originating account's worker, even when its UI receiver has been dropped.
+fn capture_response(
+	client: &MastodonClient,
+	session: &crate::autocomplete::Session,
+	revision: u64,
+	response: &NetworkResponse,
+) {
+	use crate::autocomplete::{Change, Entry};
+	match response {
+		NetworkResponse::Favorited { result: Ok(status), .. } | NetworkResponse::Boosted { result: Ok(status), .. } => {
+			let target = status.reblog.as_deref().unwrap_or(status);
+			session.interaction(Entry::from_account(&target.account, client.base_url()));
+		}
+		NetworkResponse::RelationshipUpdated { action, result: Ok(relationship), .. } => match action {
+			RelationshipAction::Unfollow | RelationshipAction::CancelFollowRequest => {
+				session.relationship(relationship.id.clone(), Change::Unfollow);
+			}
+			RelationshipAction::Block => session.relationship(relationship.id.clone(), Change::Block),
+			RelationshipAction::Unblock => session.relationship(relationship.id.clone(), Change::Unblock),
+			_ => (),
+		},
+		NetworkResponse::RelationshipLoaded { result: Ok(relationship), .. } => {
+			session.observed_relationships(vec![relationship.clone()], revision);
+		}
+		NetworkResponse::RelationshipsForListLoaded { results, .. } => {
+			session.observed_relationships(results.clone(), revision);
+		}
+		_ => (),
+	}
 }
 
 fn prepare_thread_timeline(focus: Status, context: StatusContext) -> TimelineData {
@@ -676,12 +741,23 @@ fn first_relationship_result(relationships: Vec<Relationship>) -> Result<Relatio
 fn network_loop(
 	client: &MastodonClient,
 	access_token: &str,
-	commands: &Receiver<NetworkCommand>,
+	commands: &Receiver<QueuedCommand>,
 	responses: &Sender<NetworkResponse>,
 	ui_waker: &UiWaker,
+	autocomplete: &crate::autocomplete::Session,
 ) {
+	let observation_revision = std::cell::Cell::new(0);
+	let send_response = |responses: &Sender<NetworkResponse>, waker: &UiWaker, response: NetworkResponse| {
+		capture_response(client, autocomplete, observation_revision.get(), &response);
+		send_response(responses, waker, response);
+	};
 	loop {
-		match commands.recv() {
+		let Ok(QueuedCommand { command, _foreground }) = commands.recv() else {
+			break;
+		};
+		observation_revision.set(autocomplete.snapshot().revision);
+		let command: Result<NetworkCommand, mpsc::RecvError> = Ok(command);
+		match command {
 			Ok(NetworkCommand::FetchTimeline { timeline_type, limit, max_id }) => {
 				let result = match timeline_type {
 					TimelineType::Notifications | TimelineType::Mentions => client
@@ -870,6 +946,7 @@ fn network_loop(
 								None,
 								post.scheduled_at.as_deref(),
 							);
+							capture_publication(autocomplete, client.base_url(), &res, Some(&status.account));
 							send_response(responses, ui_waker, NetworkResponse::PostComplete(res));
 						}
 					}
@@ -901,6 +978,7 @@ fn network_loop(
 					post.quoted_status_id.as_deref(),
 					post.scheduled_at.as_deref(),
 				);
+				capture_publication(autocomplete, client.base_url(), &result, post.interaction_author.as_ref());
 				send_response(responses, ui_waker, NetworkResponse::PostComplete(result));
 			}
 			Ok(NetworkCommand::EditStatus { status_id, content, sensitive, spoiler_text, language, media, poll }) => {
@@ -955,6 +1033,7 @@ fn network_loop(
 			}
 			Ok(NetworkCommand::Reply {
 				in_reply_to_id,
+				interaction_author,
 				content,
 				visibility,
 				sensitive,
@@ -980,6 +1059,7 @@ fn network_loop(
 					None,
 					scheduled_at.as_deref(),
 				);
+				capture_publication(autocomplete, client.base_url(), &result, interaction_author.as_ref());
 				send_response(responses, ui_waker, NetworkResponse::Replied(result));
 			}
 			Ok(NetworkCommand::FollowTag { name }) => {
@@ -1098,24 +1178,23 @@ fn network_loop(
 				let result = client.get_following_page(access_token, &account_id, Some(&max_id));
 				send_response(responses, ui_waker, NetworkResponse::FollowingNextPageLoaded { result });
 			}
-			Ok(NetworkCommand::FollowAccount { account_id, target_name, reblogs, action }) => {
-				let result = client.follow_account_with_options(access_token, &account_id, reblogs);
+			Ok(NetworkCommand::FollowAccount { account_id, target_acct, target_name, reblogs, action }) => {
+				let result = client.lookup_account(access_token, &target_acct).and_then(|account| {
+					let result = client.follow_account_with_options(access_token, &account.id, reblogs);
+					if result.is_ok() && action == RelationshipAction::Follow {
+						autocomplete.follow(crate::autocomplete::Entry::from_account(&account, client.base_url()));
+					}
+					result
+				});
 				send_response(
 					responses,
 					ui_waker,
 					NetworkResponse::RelationshipUpdated { _account_id: account_id, target_name, action, result },
 				);
 			}
-			Ok(NetworkCommand::ToggleFollow { account_id, acct, target_name }) => {
-				let resolved_id = if let Some(id) = account_id {
-					Some(id)
-				} else if let Ok(account) = client.lookup_account(access_token, &acct) {
-					Some(account.id)
-				} else {
-					None
-				};
-
-				if let Some(id) = resolved_id {
+			Ok(NetworkCommand::ToggleFollow { acct, target_name }) => {
+				if let Ok(account) = client.lookup_account(access_token, &acct) {
+					let id = account.id.clone();
 					if let Ok(mut rels) = client.get_relationships(access_token, slice::from_ref(&id)) {
 						if let Some(rel) = rels.pop() {
 							let (action, result) = if rel.following {
@@ -1128,6 +1207,10 @@ fn network_loop(
 									client.follow_account_with_options(access_token, &id, true),
 								)
 							};
+							if result.is_ok() && action == RelationshipAction::Follow {
+								autocomplete
+									.follow(crate::autocomplete::Entry::from_account(&account, client.base_url()));
+							}
 							send_response(
 								responses,
 								ui_waker,

--- a/src/ui/commands/account.rs
+++ b/src/ui/commands/account.rs
@@ -87,8 +87,19 @@ pub(super) fn remove_account(ctx: &mut UiCommandContext<'_>, id: String) {
 	let timeline_list = &ctx.timeline_list;
 	let suppress_selection = ctx.suppress_selection;
 	let ui_tx = ctx.ui_tx;
-	let is_active = state.config.active_account_id.as_ref() == Some(&id);
+	let is_active = state.active_account().is_some_and(|account| account.id == id);
 	state.config.accounts.retain(|a| a.id != id);
+	state.autocomplete.remove(id.clone());
+	if is_active {
+		state.config.active_account_id = None;
+		state.network_handle = None;
+		state.autocomplete.pause();
+		state.timeline_manager = crate::timeline::TimelineManager::new();
+		state.cw_expanded.clear();
+		state.current_user_id = None;
+		state.pending_post = None;
+	}
+	let _ = config::ConfigStore::new().save(&state.config);
 	state.account_timelines.remove(&id);
 	state.account_cw_expanded.remove(&id);
 

--- a/src/ui/commands/post.rs
+++ b/src/ui/commands/post.rs
@@ -22,6 +22,7 @@ use crate::{
 
 pub(super) fn post_result_to_data(post: dialogs::PostResult, quoted_status_id: Option<String>) -> network::PostData {
 	network::PostData {
+		interaction_author: post.interaction_author,
 		content: post.content,
 		visibility: post.visibility.as_api_str().to_string(),
 		sensitive: post.sensitive,
@@ -169,9 +170,15 @@ pub fn run_edit_post_dialog(
 ) {
 	let max_post_chars = state.max_post_chars;
 	let enter_to_send = state.config.enter_to_send;
-	let Some((edit, config)) =
-		dialogs::prompt_for_edit(frame, target, source_text, max_post_chars, &state.poll_limits, enter_to_send)
-	else {
+	let Some((edit, config)) = dialogs::prompt_for_edit(
+		frame,
+		state.autocomplete_session(),
+		target,
+		source_text,
+		max_post_chars,
+		&state.poll_limits,
+		enter_to_send,
+	) else {
 		return;
 	};
 	if let Some(handle) = &state.network_handle {
@@ -231,9 +238,14 @@ pub(super) fn new_post(ctx: &mut UiCommandContext<'_>) {
 			_ => None,
 		})
 	};
-	let Some((post, config)) =
-		dialogs::prompt_for_post(frame, max_post_chars, &poll_limits, enter_to_send, default_visibility)
-	else {
+	let Some((post, config)) = dialogs::prompt_for_post(
+		frame,
+		state.autocomplete_session(),
+		max_post_chars,
+		&poll_limits,
+		enter_to_send,
+		default_visibility,
+	) else {
 		return;
 	};
 	if let Some(handle) = &state.network_handle {
@@ -257,6 +269,7 @@ pub(super) fn continue_thread(ctx: &mut UiCommandContext<'_>, mut status: Box<St
 	let self_acct = state.active_account().and_then(|account| account.acct.as_deref());
 	let Some((reply, config)) = dialogs::prompt_for_reply(
 		frame,
+		state.autocomplete_session(),
 		&status,
 		max_post_chars,
 		&state.poll_limits,
@@ -271,12 +284,13 @@ pub(super) fn continue_thread(ctx: &mut UiCommandContext<'_>, mut status: Box<St
 		state.pending_thread_continuation = reply.continue_thread;
 		state.pending_post = Some(crate::PendingPost {
 			config,
-			operation: crate::PostOperation::Reply { in_reply_to_id: status.id.clone() },
+			operation: crate::PostOperation::Reply { in_reply_to_id: status.id.clone(), foreign_url: None },
 			last_result: reply.clone(),
 		});
 		let post_data = post_result_to_data(reply, None);
 		handle.send(NetworkCommand::Reply {
 			in_reply_to_id: status.id.clone(),
+			interaction_author: post_data.interaction_author,
 			content: post_data.content,
 			visibility: post_data.visibility,
 			sensitive: post_data.sensitive,
@@ -306,6 +320,7 @@ pub(super) fn reply(ctx: &mut UiCommandContext<'_>, reply_all: bool) {
 	let self_acct = state.active_account().and_then(|account| account.acct.as_deref());
 	let Some((reply, config)) = dialogs::prompt_for_reply(
 		frame,
+		state.autocomplete_session(),
 		target,
 		max_post_chars,
 		&state.poll_limits,
@@ -320,7 +335,10 @@ pub(super) fn reply(ctx: &mut UiCommandContext<'_>, reply_all: bool) {
 		state.pending_thread_continuation = reply.continue_thread;
 		state.pending_post = Some(crate::PendingPost {
 			config,
-			operation: crate::PostOperation::Reply { in_reply_to_id: target.id.clone() },
+			operation: crate::PostOperation::Reply {
+				in_reply_to_id: target.id.clone(),
+				foreign_url: foreign_url(state, target.url.as_ref()),
+			},
 			last_result: reply.clone(),
 		});
 		let post_data = post_result_to_data(reply, None);
@@ -339,6 +357,7 @@ pub(super) fn reply(ctx: &mut UiCommandContext<'_>, reply_all: bool) {
 		}
 		handle.send(NetworkCommand::Reply {
 			in_reply_to_id: target.id.clone(),
+			interaction_author: post_data.interaction_author,
 			content: post_data.content,
 			visibility: post_data.visibility,
 			sensitive: post_data.sensitive,
@@ -389,9 +408,14 @@ pub(super) fn prompt_for_quote(ctx: &mut UiCommandContext<'_>, target: Box<Statu
 		return;
 	}
 	let target_id = target.id.clone();
-	let Some((post, config)) =
-		dialogs::prompt_for_quote(frame, &target, state.max_post_chars, &state.poll_limits, state.config.enter_to_send)
-	else {
+	let Some((post, config)) = dialogs::prompt_for_quote(
+		frame,
+		state.autocomplete_session(),
+		&target,
+		state.max_post_chars,
+		&state.poll_limits,
+		state.config.enter_to_send,
+	) else {
 		return;
 	};
 	if let Some(handle) = &state.network_handle {
@@ -863,8 +887,13 @@ pub(super) fn recover_draft(ctx: &mut UiCommandContext<'_>) {
 
 	let cmd = match pending.operation {
 		crate::PostOperation::NewPost => NetworkCommand::PostStatus { post: post_data },
-		crate::PostOperation::Reply { ref in_reply_to_id } => NetworkCommand::Reply {
+		crate::PostOperation::Reply { foreign_url: Some(ref url), .. } => NetworkCommand::ResolveAndInteract {
+			url: url.clone(),
+			interaction: ForeignInteraction::Reply(Box::new(post_data)),
+		},
+		crate::PostOperation::Reply { ref in_reply_to_id, .. } => NetworkCommand::Reply {
 			in_reply_to_id: in_reply_to_id.clone(),
+			interaction_author: post_data.interaction_author,
 			content: post_data.content,
 			visibility: post_data.visibility,
 			sensitive: post_data.sensitive,

--- a/src/ui/commands/user.rs
+++ b/src/ui/commands/user.rs
@@ -399,6 +399,8 @@ pub(super) fn view_mentions(ctx: &mut UiCommandContext<'_>) {
 				locked: false,
 				bot: false,
 				discoverable: None,
+				moved: None,
+				suspended: None,
 				source: None,
 			},
 		};
@@ -564,6 +566,8 @@ pub(super) fn toggle_follow(ctx: &mut UiCommandContext<'_>) {
 				locked: false,
 				bot: false,
 				discoverable: None,
+				moved: None,
+				suspended: None,
 				source: None,
 			});
 		}
@@ -583,8 +587,7 @@ pub(super) fn toggle_follow(ctx: &mut UiCommandContext<'_>) {
 
 	if let Some(net) = &state.network_handle {
 		net.send(NetworkCommand::ToggleFollow {
-			account_id: if selected_user.id.is_empty() { None } else { Some(selected_user.id) },
-			acct: selected_user.acct.clone(),
+			acct: selected_user.full_acct(),
 			target_name: selected_user.username.clone(),
 		});
 	} else {

--- a/src/ui/dialogs.rs
+++ b/src/ui/dialogs.rs
@@ -1,5 +1,6 @@
 mod accounts;
 mod auth;
+pub mod autocomplete_picker;
 mod common;
 mod compose;
 mod filters;

--- a/src/ui/dialogs/autocomplete_picker.rs
+++ b/src/ui/dialogs/autocomplete_picker.rs
@@ -1,0 +1,550 @@
+//! Modal picker notifications bypass the application's (possibly occupied) command handler.
+use std::{cell::RefCell, rc::Rc, sync::Arc};
+
+use wxdragon::{
+	prelude::*,
+	widgets::list_ctrl::{ListColumnFormat, ListCtrl, ListCtrlStyle, ListItemState},
+};
+
+use crate::autocomplete::{Availability, Entry, Matches, Session, Snapshot, text};
+
+thread_local! {
+	static SUBSCRIBER: RefCell<Option<Rc<dyn Fn()>>> = RefCell::new(None);
+}
+
+#[cfg(test)]
+type PickerTestHook = Rc<dyn Fn(Dialog, TextCtrl, ListCtrl, Button)>;
+#[cfg(test)]
+thread_local! { static TEST_HOOK: RefCell<Option<PickerTestHook>> = RefCell::new(None); }
+
+pub fn dispatch_update() {
+	let callback = SUBSCRIBER.with(|slot| slot.borrow().clone());
+	if let Some(callback) = callback {
+		callback();
+	}
+}
+
+struct Subscription;
+impl Drop for Subscription {
+	fn drop(&mut self) {
+		SUBSCRIBER.with(|slot| slot.borrow_mut().take());
+	}
+}
+
+struct Rows {
+	snapshot: Arc<Snapshot>,
+	matches: Matches,
+}
+impl Rows {
+	fn entry(&self, row: i32) -> Option<&Entry> {
+		let index = self.matches.get(usize::try_from(row).ok()?)?;
+		self.snapshot.entries.get(index).map(|(_, e)| e)
+	}
+}
+
+fn unavailable(parent: Dialog, message: &str) {
+	let dialog = Dialog::builder(&parent, "User autocomplete").with_size(510, 180).build();
+	let sizer = BoxSizer::builder(Orientation::Vertical).build();
+	let label = StaticText::builder(&dialog).with_label(message).build();
+	let ok = Button::builder(&dialog).with_id(ID_OK).with_label("OK").build();
+	ok.set_default();
+	sizer.add(&label, 1, SizerFlag::Expand | SizerFlag::All, 12);
+	sizer.add(&ok, 0, SizerFlag::AlignRight | SizerFlag::All, 12);
+	dialog.set_sizer(sizer, true);
+	ok.on_click(move |_| dialog.end_modal(ID_OK));
+	ok.set_focus();
+	dialog.show_modal();
+	dialog.destroy();
+}
+
+fn choose(parent: Dialog, session: &Session, initial_filter: &str) -> Option<Entry> {
+	if !session.eligible() {
+		return None;
+	}
+	let snapshot = session.snapshot();
+	let message = match &snapshot.availability {
+		Availability::Loading => Some("User autocomplete is loading. Please try again shortly."),
+		Availability::Building => Some("User autocomplete is building its cache. Please try again shortly."),
+		Availability::Unavailable(message) => Some(message.as_str()),
+		Availability::Usable | Availability::UsablePartial | Availability::CompletedEmpty => None,
+	};
+	if let Some(message) = message {
+		unavailable(parent, message);
+		return None;
+	}
+	let dialog = Dialog::builder(&parent, "User autocomplete").with_size(620, 480).build();
+	let panel = Panel::builder(&dialog).build();
+	let sizer = BoxSizer::builder(Orientation::Vertical).build();
+	let filter_label = StaticText::builder(&panel).with_label("&Filter").build();
+	let filter = TextCtrl::builder(&panel).with_value(initial_filter).build();
+	filter.set_name("Filter");
+	let users_label = StaticText::builder(&panel).with_label("&Users").build();
+	let users = ListCtrl::builder(&panel)
+		.with_style(ListCtrlStyle::Report | ListCtrlStyle::Virtual | ListCtrlStyle::SingleSel | ListCtrlStyle::NoHeader)
+		.build();
+	users.set_name("Users");
+	users.insert_column(0, "Users", ListColumnFormat::Left, 570);
+	let buttons = BoxSizer::builder(Orientation::Horizontal).build();
+	let ok = Button::builder(&panel).with_id(ID_OK).with_label("OK").build();
+	let cancel = Button::builder(&panel).with_id(ID_CANCEL).with_label("Cancel").build();
+	ok.set_default();
+	buttons.add_stretch_spacer(1);
+	buttons.add(&ok, 0, SizerFlag::Right, 8);
+	buttons.add(&cancel, 0, SizerFlag::Right, 8);
+	sizer.add(&filter_label, 0, SizerFlag::All, 8);
+	sizer.add(&filter, 0, SizerFlag::Expand | SizerFlag::Left | SizerFlag::Right, 8);
+	sizer.add(&users_label, 0, SizerFlag::All, 8);
+	sizer.add(&users, 1, SizerFlag::Expand | SizerFlag::Left | SizerFlag::Right, 8);
+	if let Some(error) = &snapshot.persistence_error {
+		let label =
+			StaticText::builder(&panel).with_label(&format!("Cache changes are not being saved: {error}")).build();
+		sizer.add(&label, 0, SizerFlag::Expand | SizerFlag::All, 8);
+	}
+	sizer.add_sizer(&buttons, 0, SizerFlag::Expand | SizerFlag::All, 8);
+	panel.set_sizer(sizer, true);
+	let outer = BoxSizer::builder(Orientation::Vertical).build();
+	outer.add(&panel, 1, SizerFlag::Expand, 0);
+	dialog.set_sizer(outer, true);
+	dialog.set_affirmative_id(ID_OK);
+	dialog.set_escape_id(ID_CANCEL);
+	let rows = Rc::new(RefCell::new(Rows { matches: snapshot.matching(initial_filter), snapshot }));
+	let text_rows = rows.clone();
+	users.set_virtual_text_callback(move |row, _| {
+		text_rows.borrow().entry(i32::try_from(row).unwrap_or(-1)).map_or_else(|| "No matches".into(), Entry::label)
+	});
+	let refresh_rows = rows.clone();
+	let refresh_session = session.clone();
+	let refresh: Rc<dyn Fn(bool)> = Rc::new(move |background| {
+		if !refresh_session.eligible() {
+			dialog.end_modal(ID_CANCEL);
+			return;
+		}
+		let snapshot = refresh_session.snapshot();
+		if background
+			&& snapshot.revision == refresh_rows.borrow().snapshot.revision
+			&& Arc::ptr_eq(&snapshot, &refresh_rows.borrow().snapshot)
+		{
+			return;
+		}
+		let selected = if background {
+			refresh_rows.borrow().entry(users.get_first_selected_item()).map(|e| e.id.clone())
+		} else {
+			None
+		};
+		let updated = Rows { matches: snapshot.matching(&filter.get_value()), snapshot };
+		let count = updated.matches.len();
+		let selection = selected
+			.and_then(|id| {
+				(0..count).position(|row| {
+					updated.matches.get(row).is_some_and(|index| updated.snapshot.entries[index].1.id == id)
+				})
+			})
+			.unwrap_or(0);
+		*refresh_rows.borrow_mut() = updated;
+		// Drop RefCell borrows before native calls, which can synchronously request row text.
+		users.set_item_state(-1, ListItemState::default(), ListItemState::Selected | ListItemState::Focused);
+		users.set_item_count(i64::try_from(count.max(1)).unwrap_or(i64::MAX));
+		let selection = i64::try_from(selection).unwrap_or(0);
+		users.set_item_state(
+			selection,
+			ListItemState::Selected | ListItemState::Focused,
+			ListItemState::Selected | ListItemState::Focused,
+		);
+		users.ensure_visible(selection);
+		users.refresh_items(0, i64::try_from(count.max(1) - 1).unwrap_or(0));
+		ok.enable(count > 0);
+	});
+	refresh(false);
+	let update = refresh.clone();
+	filter.on_text_changed(move |_| update(false));
+	let update = refresh;
+	SUBSCRIBER.with(|slot| *slot.borrow_mut() = Some(Rc::new(move || update(true))));
+	let subscription = Subscription;
+	let selection_rows = rows.clone();
+	users.on_item_selected(move |_| {
+		ok.enable(selection_rows.borrow().entry(users.get_first_selected_item()).is_some());
+	});
+	let deselect_rows = rows.clone();
+	users.on_item_deselected(move |_| {
+		ok.enable(deselect_rows.borrow().entry(users.get_first_selected_item()).is_some());
+	});
+	let accept_rows = rows.clone();
+	let accept_session = session.clone();
+	let accept: Rc<dyn Fn()> = Rc::new(move || {
+		if !accept_session.eligible() {
+			dialog.end_modal(ID_CANCEL);
+			return;
+		}
+		if let Some(id) = accept_rows.borrow().entry(users.get_first_selected_item()).map(|e| e.id.clone())
+			&& accept_session.snapshot().entries.iter().any(|(_, e)| e.id == id)
+		{
+			dialog.end_modal(ID_OK);
+		}
+	});
+	let click = accept.clone();
+	ok.on_click(move |_| click());
+	cancel.on_click(move |_| dialog.end_modal(ID_CANCEL));
+	let activate = accept.clone();
+	users.on_item_activated(move |_| activate());
+	// CHAR_HOOK runs before default buttons or parent accelerators, including on No matches.
+	let handle_key: Rc<dyn Fn(WindowEventData)> = Rc::new(move |data| {
+		if let WindowEventData::Keyboard(key) = &data {
+			match key.get_key_code() {
+				Some(13) => {
+					accept();
+					data.skip(false);
+					return;
+				}
+				Some(27) => {
+					dialog.end_modal(ID_CANCEL);
+					data.skip(false);
+					return;
+				}
+				Some(70) if key.alt_down() => {
+					filter.set_focus();
+					data.skip(false);
+					return;
+				}
+				Some(85) if key.alt_down() => {
+					users.set_focus();
+					data.skip(false);
+					return;
+				}
+				_ => (),
+			}
+		}
+		data.skip(true);
+	});
+	let hook = handle_key.clone();
+	dialog.bind_internal(EventType::CHAR_HOOK, move |event| hook(WindowEventData::new(event)));
+	let filter_keys = handle_key.clone();
+	filter.on_key_down(move |event| filter_keys(event));
+	users.bind_internal(EventType::KEY_DOWN, move |event| handle_key(WindowEventData::new(event)));
+	dialog.on_close(move |event| {
+		dialog.end_modal(ID_CANCEL);
+		event.skip(false);
+	});
+	dialog.centre();
+	if initial_filter.chars().any(char::is_alphanumeric) {
+		users.set_focus();
+	} else {
+		filter.set_focus();
+	}
+	#[cfg(test)]
+	TEST_HOOK.with(|hook| {
+		if let Some(hook) = hook.borrow().as_ref() {
+			hook(dialog, filter, users, ok);
+		}
+	});
+	let result = dialog.show_modal();
+	drop(subscription);
+	let entry = if result == ID_OK && session.eligible() {
+		let id = rows.borrow().entry(users.get_first_selected_item()).map(|e| e.id.clone());
+		id.and_then(|id| session.snapshot().entries.iter().find(|(_, e)| e.id == id).map(|(_, e)| e.clone()))
+	} else {
+		None
+	};
+	users.clear_virtual_text_callback();
+	dialog.destroy();
+	entry
+}
+
+pub fn insert(parent: Dialog, body: TextCtrl, session: &Session) {
+	let original = body.get_value();
+	let (from, to) = body.get_selection();
+	let byte = |position| text::native_to_byte(&original, usize::try_from(position).unwrap_or(0), cfg!(windows));
+	let edit = text::prepare(&original, byte(body.get_insertion_point()), byte(from)..byte(to));
+	if let Some(entry) = choose(parent, session, &edit.filter)
+		&& session.eligible()
+	{
+		let (replacement, caret) = edit.replacement(&original, &entry.address);
+		let from = text::byte_to_native(&original, edit.range.start, cfg!(windows));
+		let to = text::byte_to_native(&original, edit.range.end, cfg!(windows));
+		let mut updated = original;
+		updated.replace_range(edit.range, &replacement);
+		let native_caret = text::byte_to_native(&updated, caret, cfg!(windows));
+		undoable_replace(body, from, to, &replacement);
+		body.set_insertion_point(i64::try_from(native_caret).unwrap_or(i64::MAX));
+	}
+	body.set_focus();
+}
+
+#[cfg(windows)]
+fn undoable_replace(body: TextCtrl, from: usize, to: usize, text: &str) {
+	use windows::Win32::{
+		Foundation::{HWND, LPARAM, WPARAM},
+		UI::{
+			Controls::{EM_REPLACESEL, EM_SETSEL},
+			WindowsAndMessaging::SendMessageW,
+		},
+	};
+	let text: Vec<u16> = text.encode_utf16().chain([0]).collect();
+	unsafe {
+		SendMessageW(
+			HWND(body.get_handle()),
+			EM_SETSEL,
+			Some(WPARAM(from)),
+			Some(LPARAM(isize::try_from(to).unwrap_or(isize::MAX))),
+		);
+		SendMessageW(HWND(body.get_handle()), EM_REPLACESEL, Some(WPARAM(1)), Some(LPARAM(text.as_ptr() as isize)));
+	}
+}
+
+#[cfg(all(test, windows))]
+mod native_tests {
+	use std::{
+		cell::Cell,
+		sync::{
+			Mutex,
+			atomic::{AtomicBool, Ordering},
+		},
+		time::{Duration, Instant},
+	};
+
+	use windows::Win32::{
+		Foundation::{HWND, LPARAM, WPARAM},
+		UI::{
+			Controls::EM_UNDO,
+			WindowsAndMessaging::{PostMessageW, SendMessageW, WM_KEYDOWN},
+		},
+	};
+
+	use super::*;
+
+	#[test]
+	#[ignore = "Requires a Windows desktop; opens an isolated native picker without configured accounts"]
+	fn native_picker_live_updates_keys_positions_and_undo() {
+		let failure = Arc::new(Mutex::new(None::<String>));
+		let failure_ui = failure.clone();
+		wxdragon::main(move |_| {
+			let frame = Frame::builder().with_title("Fedra autocomplete UI test").build();
+			let alive = Arc::new(AtomicBool::new(true));
+			let waker = crate::ui_wake::UiWaker::with_event(frame, alive.clone(), crate::ID_AUTOCOMPLETE_WAKE);
+			let wake_handler = waker.clone();
+			frame.bind_with_id_internal(EventType::MENU, crate::ID_AUTOCOMPLETE_WAKE, move |_| {
+				wake_handler.reset();
+				dispatch_update();
+			});
+			let dir = std::env::temp_dir().join(format!("fedra-native-picker-{}", std::process::id()));
+			let service = crate::autocomplete::Service::start(
+				dir.join("autocomplete-cache.json"),
+				["a".into()].into_iter().collect(),
+				waker,
+			);
+			service.select_for_ui_test("a");
+			let session = service.session("a".into());
+			let alice = Entry {
+				id: "alice".into(),
+				unavailable: false,
+				address: "@alice@example.org".into(),
+				display_name: "Alison Example".into(),
+				revision: 0,
+			};
+			session.interaction(alice.clone());
+			let deadline = Instant::now() + Duration::from_secs(3);
+			while session.snapshot().entries.is_empty() && Instant::now() < deadline {
+				std::thread::sleep(Duration::from_millis(5));
+			}
+			let parent = Dialog::builder(&frame, "Composer test").build();
+			let body = TextCtrl::builder(&parent).with_style(TextCtrlStyle::MultiLine).build();
+			let run = || -> anyhow::Result<()> {
+				let original = "😀 hello\n@al!";
+				body.set_value(original);
+				body.set_insertion_point_end();
+				anyhow::ensure!(
+					usize::try_from(body.get_insertion_point())?
+						== text::byte_to_native(original, original.len(), true),
+					"Native multiline/UTF-16 adapter disagrees with wxMSW"
+				);
+				let caret = original.find('!').unwrap();
+				let edit = text::prepare(original, caret, caret..caret);
+				let (replacement, _) = edit.replacement(original, &alice.address);
+				undoable_replace(
+					body,
+					text::byte_to_native(original, edit.range.start, true),
+					text::byte_to_native(original, edit.range.end, true),
+					&replacement,
+				);
+				anyhow::ensure!(
+					body.get_value() == "😀 hello\n@alice@example.org!",
+					"Native insertion changed unrelated text"
+				);
+				unsafe {
+					SendMessageW(HWND(body.get_handle()), EM_UNDO, None, None);
+				}
+				anyhow::ensure!(body.get_value() == original, "One Undo did not restore the original text");
+
+				let timer_keepalive: Rc<RefCell<Option<Timer<Dialog>>>> = Rc::new(RefCell::new(None));
+				let timers = timer_keepalive.clone();
+				let errors = failure_ui.clone();
+				let session_updates = session.clone();
+				let alice_updates = alice.clone();
+				TEST_HOOK.with(|slot| {
+					*slot.borrow_mut() = Some(Rc::new(move |dialog, filter, users, ok| {
+						let timer = Timer::new(&dialog);
+						let phase = Cell::new(0);
+						let started = Instant::now();
+						let errors = errors.clone();
+						let updates = session_updates.clone();
+						let alice = alice_updates.clone();
+						timer.on_tick(move |_| {
+							let step =
+								|| -> anyhow::Result<()> {
+									anyhow::ensure!(
+										started.elapsed() < Duration::from_secs(5),
+										"Picker timed out at phase {} (rows {}, first {})",
+										phase.get(),
+										users.get_item_count(),
+										users.get_item_text(0, 0)
+									);
+									match phase.get() {
+										0 => {
+											anyhow::ensure!(
+												users.get_item_count() == 1
+													&& users.get_first_selected_item() == 0 && ok.is_enabled(),
+												"Initial result selection"
+											);
+											anyhow::ensure!(users.has_focus(), "Seeded mention must focus Users");
+											filter.set_focus();
+											filter.set_value("does-not-match");
+											phase.set(1);
+										}
+										1 => {
+											anyhow::ensure!(
+												users.get_item_count() == 1
+													&& users.get_item_text(0, 0) == "No matches"
+													&& users.get_first_selected_item() == 0 && !ok.is_enabled(),
+												"No matches row must be selected and OK disabled"
+											);
+											unsafe {
+												PostMessageW(
+													Some(HWND(filter.get_handle())),
+													WM_KEYDOWN,
+													WPARAM(13),
+													LPARAM(0),
+												)?;
+											}
+											phase.set(2);
+										}
+										2 => {
+											filter.set_value("");
+											updates.relationship("alice".into(), crate::autocomplete::Change::Unfollow);
+											phase.set(3);
+										}
+										3 if users.get_item_text(0, 0) == "No matches" => {
+											anyhow::ensure!(filter.has_focus(), "Background removal changed focus");
+											updates.interaction(alice.clone());
+											phase.set(4);
+										}
+										4 if users.get_item_text(0, 0).contains("@alice") => {
+											updates.interaction(Entry {
+												id: "aaron".into(),
+												unavailable: false,
+												address: "@aaron@example.org".into(),
+												display_name: String::new(),
+												revision: 0,
+											});
+											phase.set(5);
+										}
+										5 if users.get_item_count() == 2 => {
+											anyhow::ensure!(
+												users.get_first_selected_item() == 1 && filter.has_focus(),
+												"Background additions must preserve selected identity and focus"
+											);
+											unsafe {
+												PostMessageW(
+													Some(HWND(filter.get_handle())),
+													WM_KEYDOWN,
+													WPARAM(27),
+													LPARAM(0),
+												)?;
+											}
+											phase.set(6);
+										}
+										_ => (),
+									}
+									Ok(())
+								};
+							if let Err(error) = step() {
+								*errors.lock().unwrap() = Some(error.to_string());
+								dialog.end_modal(ID_CANCEL);
+							}
+						});
+						timer.start(30, false);
+						*timers.borrow_mut() = Some(timer);
+					}))
+				});
+				// This prefix matches the display name only, exercising indexed virtual rows.
+				let result = choose(parent, &session, "@alis");
+				if let Some(timer) = timer_keepalive.borrow_mut().take() {
+					timer.stop();
+				}
+				TEST_HOOK.with(|slot| slot.borrow_mut().take());
+				anyhow::ensure!(result.is_none(), "No matches Enter or Escape accepted an account");
+				// Exercise the complete body adapter and acceptance path, including one-step Undo.
+				for key in [13, 27] {
+					let timers = timer_keepalive.clone();
+					TEST_HOOK.with(|slot| {
+						*slot.borrow_mut() = Some(Rc::new(move |dialog, filter, users, _| {
+							let timer = Timer::new(&dialog);
+							timer.on_tick(move |_| {
+								let target = if key == 13 { users.get_handle() } else { filter.get_handle() };
+								unsafe {
+									let _ = PostMessageW(Some(HWND(target)), WM_KEYDOWN, WPARAM(key), LPARAM(0));
+								}
+							});
+							timer.start(30, true);
+							*timers.borrow_mut() = Some(timer);
+						}))
+					});
+					body.set_insertion_point(i64::try_from(text::byte_to_native(original, caret, true))?);
+					let selection = body.get_selection();
+					insert(parent, body, &session);
+					if let Some(timer) = timer_keepalive.borrow_mut().take() {
+						timer.stop();
+					}
+					TEST_HOOK.with(|slot| slot.borrow_mut().take());
+					if key == 13 {
+						let expected = "😀 hello\n@alice@example.org!";
+						anyhow::ensure!(
+							body.get_value() == expected,
+							"Picker acceptance failed to replace the mention"
+						);
+						anyhow::ensure!(
+							usize::try_from(body.get_insertion_point())?
+								== text::byte_to_native(expected, expected.len() - 1, true),
+							"Caret must precede following punctuation"
+						);
+						unsafe {
+							SendMessageW(HWND(body.get_handle()), EM_UNDO, None, None);
+						}
+					} else {
+						anyhow::ensure!(body.get_selection() == selection, "Cancel changed selection");
+					}
+					anyhow::ensure!(body.get_value() == original, "Cancel or Undo changed the original body");
+				}
+				Ok(())
+			};
+			if let Err(error) = run() {
+				*failure_ui.lock().unwrap() = Some(error.to_string());
+			}
+			service.shutdown();
+			let deadline = Instant::now() + Duration::from_secs(3);
+			while service.shutdown_result().is_none() && Instant::now() < deadline {
+				std::thread::sleep(Duration::from_millis(5));
+			}
+			alive.store(false, Ordering::SeqCst);
+			parent.destroy();
+			frame.destroy();
+			let _ = std::fs::remove_file(dir.join("autocomplete-cache.json"));
+			let _ = std::fs::remove_dir(dir);
+		})
+		.unwrap();
+		assert!(failure.lock().unwrap().is_none(), "Native UI check failed: {:?}", failure.lock().unwrap());
+	}
+}
+
+#[cfg(not(windows))]
+fn undoable_replace(body: TextCtrl, from: usize, to: usize, text: &str) {
+	body.replace(i64::try_from(from).unwrap_or(i64::MAX), i64::try_from(to).unwrap_or(i64::MAX), text);
+}

--- a/src/ui/dialogs/compose.rs
+++ b/src/ui/dialogs/compose.rs
@@ -45,6 +45,7 @@ impl PostVisibility {
 
 #[derive(Debug, Clone)]
 pub struct PostResult {
+	pub interaction_author: Option<crate::mastodon::Account>,
 	pub content: String,
 	pub visibility: PostVisibility,
 	pub sensitive: bool,
@@ -75,6 +76,8 @@ pub struct PostPoll {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub struct ComposeDialogConfig {
+	pub autocomplete: Option<crate::autocomplete::Session>,
+	pub interaction_author: Option<crate::mastodon::Account>,
 	pub title_prefix: String,
 	pub ok_label: String,
 	pub initial_content: String,
@@ -784,6 +787,9 @@ pub fn prompt_for_compose(
 	initial_media: Vec<PostMedia>,
 	initial_poll: Option<PostPoll>,
 ) -> Option<(PostResult, ComposeDialogConfig)> {
+	if config.autocomplete.as_ref().is_some_and(|session| !session.eligible()) {
+		return None;
+	}
 	let max_chars = max_chars.unwrap_or(DEFAULT_MAX_POST_CHARS);
 	let title_prefix = config.title_prefix.clone();
 	let ok_label = config.ok_label.clone();
@@ -812,6 +818,15 @@ pub fn prompt_for_compose(
 
 	let content_label = StaticText::builder(&panel).with_label("&What's on your mind?").build();
 	let content_text = TextCtrl::builder(&panel).with_style(TextCtrlStyle::MultiLine).build();
+	let autocomplete_button = Button::builder(&panel).with_label("&Autocomplete...").build();
+	autocomplete_button.enable(config.autocomplete.is_some());
+	if let Some(session) = config.autocomplete.clone() {
+		// Let the native button mnemonic handle Alt+A, including its system-character
+		// message, before opening another modal dialog.
+		autocomplete_button.on_click(move |_| {
+			super::autocomplete_picker::insert(dialog, content_text, &session);
+		});
+	}
 	let cw_checkbox = CheckBox::builder(&panel).with_label("&Content warning").build();
 	let cw_label = StaticText::builder(&panel).with_label("Warning text:").build();
 	let cw_text = TextCtrl::builder(&panel).build();
@@ -885,6 +900,7 @@ pub fn prompt_for_compose(
 	button_sizer.add(&cancel_button, 0, SizerFlag::Right, 8);
 	main_sizer.add(&content_label, 0, SizerFlag::Expand | SizerFlag::All, 8);
 	main_sizer.add(&content_text, 1, SizerFlag::Expand | SizerFlag::Left | SizerFlag::Right, 8);
+	main_sizer.add(&autocomplete_button, 0, SizerFlag::Left | SizerFlag::Right | SizerFlag::Top, 8);
 	main_sizer.add(&cw_checkbox, 0, SizerFlag::Expand | SizerFlag::All, 8);
 	main_sizer.add(&cw_label, 0, SizerFlag::Expand | SizerFlag::Left | SizerFlag::Right, 8);
 	main_sizer.add(&cw_text, 0, SizerFlag::Expand | SizerFlag::Left | SizerFlag::Right, 8);
@@ -1105,6 +1121,7 @@ pub fn prompt_for_compose(
 	}
 	Some((
 		PostResult {
+			interaction_author: config.interaction_author.clone(),
 			content: trimmed.to_string(),
 			visibility,
 			sensitive: *sensitive_state.borrow(),
@@ -1122,6 +1139,7 @@ pub fn prompt_for_compose(
 
 pub fn prompt_for_post(
 	frame: &Frame,
+	autocomplete: Option<crate::autocomplete::Session>,
 	max_chars: Option<usize>,
 	poll_limits: &PollLimits,
 	enter_to_send: bool,
@@ -1133,6 +1151,8 @@ pub fn prompt_for_post(
 		poll_limits,
 		enter_to_send,
 		ComposeDialogConfig {
+			autocomplete,
+			interaction_author: None,
 			title_prefix: "Post".to_string(),
 			ok_label: "Post".to_string(),
 			initial_content: String::new(),
@@ -1153,6 +1173,7 @@ pub fn prompt_for_post(
 
 pub fn prompt_for_reply(
 	frame: &Frame,
+	autocomplete: Option<crate::autocomplete::Session>,
 	replying_to: &Status,
 	max_chars: Option<usize>,
 	poll_limits: &PollLimits,
@@ -1201,6 +1222,8 @@ pub fn prompt_for_reply(
 		poll_limits,
 		enter_to_send,
 		ComposeDialogConfig {
+			autocomplete,
+			interaction_author: Some(replying_to.account.clone()),
 			title_prefix: format!("Reply to {author}"),
 			ok_label: "Post".to_string(),
 			initial_content: mention,
@@ -1221,6 +1244,7 @@ pub fn prompt_for_reply(
 
 pub fn prompt_for_edit(
 	frame: &Frame,
+	autocomplete: Option<crate::autocomplete::Session>,
 	status: &Status,
 	source_text: Option<&str>,
 	max_chars: Option<usize>,
@@ -1252,6 +1276,8 @@ pub fn prompt_for_edit(
 		poll_limits,
 		enter_to_send,
 		ComposeDialogConfig {
+			autocomplete,
+			interaction_author: None,
 			title_prefix: "Edit Post".to_string(),
 			ok_label: "Save".to_string(),
 			initial_content: source_text.map(ToOwned::to_owned).unwrap_or_else(|| status.display_text()),
@@ -1272,6 +1298,7 @@ pub fn prompt_for_edit(
 
 pub fn prompt_for_quote(
 	frame: &Frame,
+	autocomplete: Option<crate::autocomplete::Session>,
 	quoting: &Status,
 	max_chars: Option<usize>,
 	poll_limits: &PollLimits,
@@ -1292,6 +1319,8 @@ pub fn prompt_for_quote(
 		poll_limits,
 		enter_to_send,
 		ComposeDialogConfig {
+			autocomplete,
+			interaction_author: Some(quoting.account.clone()),
 			title_prefix: format!("Quote {author}"),
 			ok_label: "Post".to_string(),
 			initial_content: String::new(),

--- a/src/ui/dialogs/follow_list.rs
+++ b/src/ui/dialogs/follow_list.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::mpsc::Sender};
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use wxdragon::{event::MenuEvents, prelude::*};
 
@@ -28,7 +28,7 @@ impl FollowListDialog {
 		first_page: &[Account],
 		total_count: u64,
 		account_id: Option<String>,
-		net_tx: Sender<NetworkCommand>,
+		net_tx: crate::network::NetworkSender,
 		ui_tx: crate::ui_wake::UiCommandSender,
 		on_view_timeline: F,
 		on_close: C,
@@ -198,6 +198,7 @@ impl FollowListDialog {
 			let rel = relationships_handler.borrow().get(&account_id).cloned();
 			let cmd = match id {
 				user_actions::ID_ACTION_FOLLOW => NetworkCommand::FollowAccount {
+					target_acct: account.full_acct(),
 					account_id,
 					target_name,
 					reblogs: true,
@@ -213,12 +214,14 @@ impl FollowListDialog {
 					},
 				},
 				user_actions::ID_ACTION_SHOW_BOOSTS => NetworkCommand::FollowAccount {
+					target_acct: account.full_acct(),
 					account_id,
 					target_name,
 					reblogs: true,
 					action: crate::network::RelationshipAction::ShowBoosts,
 				},
 				user_actions::ID_ACTION_HIDE_BOOSTS => NetworkCommand::FollowAccount {
+					target_acct: account.full_acct(),
 					account_id,
 					target_name,
 					reblogs: false,

--- a/src/ui/dialogs/manage_list_members.rs
+++ b/src/ui/dialogs/manage_list_members.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc, sync::mpsc::Sender};
+use std::{cell::RefCell, rc::Rc};
 
 use wxdragon::prelude::*;
 
@@ -22,7 +22,7 @@ impl ManageListMembersDialog {
 		list_id: String,
 		list_title: &str,
 		members: Vec<Account>,
-		net_tx: Sender<NetworkCommand>,
+		net_tx: crate::network::NetworkSender,
 		on_close: F,
 	) -> Self
 	where

--- a/src/ui/dialogs/manage_lists.rs
+++ b/src/ui/dialogs/manage_lists.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc, sync::mpsc::Sender};
+use std::{cell::RefCell, rc::Rc};
 
 use wxdragon::prelude::*;
 
@@ -15,7 +15,12 @@ pub struct ManageListsDialog {
 }
 
 impl ManageListsDialog {
-	pub fn new<F>(frame: &Frame, lists: Vec<crate::mastodon::List>, net_tx: Sender<NetworkCommand>, on_close: F) -> Self
+	pub fn new<F>(
+		frame: &Frame,
+		lists: Vec<crate::mastodon::List>,
+		net_tx: crate::network::NetworkSender,
+		on_close: F,
+	) -> Self
 	where
 		F: Fn() + 'static + Clone,
 	{

--- a/src/ui/dialogs/profile.rs
+++ b/src/ui/dialogs/profile.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc, sync::mpsc::Sender};
+use std::{cell::RefCell, rc::Rc};
 
 use wxdragon::prelude::*;
 
@@ -22,7 +22,7 @@ impl ProfileDialog {
 		frame: &Frame,
 		account: MastodonAccount,
 		current_user_id: Option<&str>,
-		net_tx: std::sync::mpsc::Sender<NetworkCommand>,
+		net_tx: crate::network::NetworkSender,
 		ui_tx: crate::ui_wake::UiCommandSender,
 		on_view_timeline: F,
 		on_close: C,
@@ -320,7 +320,7 @@ impl HashtagDialog {
 	pub fn new<F>(
 		frame: &Frame,
 		tags: Vec<Tag>,
-		net_tx: Sender<NetworkCommand>,
+		net_tx: crate::network::NetworkSender,
 		ui_tx: crate::ui_wake::UiCommandSender,
 		on_close: F,
 	) -> Self

--- a/src/ui/dialogs/user_actions.rs
+++ b/src/ui/dialogs/user_actions.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, fmt::Write, rc::Rc, sync::mpsc::Sender};
+use std::{cell::RefCell, fmt::Write, rc::Rc};
 
 use wxdragon::prelude::*;
 
@@ -62,7 +62,7 @@ pub(crate) fn setup_actions_button(
 	button: Button,
 	account: Rc<RefCell<Account>>,
 	relationship: Rc<RefCell<Option<Relationship>>>,
-	net_tx: Sender<NetworkCommand>,
+	net_tx: crate::network::NetworkSender,
 	ui_tx: crate::ui_wake::UiCommandSender,
 ) {
 	let relationship_click = relationship.clone();
@@ -136,6 +136,7 @@ pub(crate) fn setup_actions_button(
 		}
 		let cmd = match id {
 			ID_ACTION_FOLLOW => NetworkCommand::FollowAccount {
+				target_acct: account.full_acct(),
 				account_id,
 				target_name,
 				reblogs: true,
@@ -151,12 +152,14 @@ pub(crate) fn setup_actions_button(
 				},
 			},
 			ID_ACTION_SHOW_BOOSTS => NetworkCommand::FollowAccount {
+				target_acct: account.full_acct(),
 				account_id,
 				target_name,
 				reblogs: true,
 				action: crate::network::RelationshipAction::ShowBoosts,
 			},
 			ID_ACTION_HIDE_BOOSTS => NetworkCommand::FollowAccount {
+				target_acct: account.full_acct(),
 				account_id,
 				target_name,
 				reblogs: false,

--- a/src/ui_wake.rs
+++ b/src/ui_wake.rs
@@ -11,13 +11,27 @@ use crate::{ID_UI_WAKE, UiCommand};
 #[derive(Clone)]
 pub struct UiWaker {
 	frame_ptr: usize,
+	event_id: i32,
 	pending: Arc<AtomicBool>,
 	alive: Arc<AtomicBool>,
 }
 
 impl UiWaker {
+	#[cfg(test)]
+	pub(crate) fn silent() -> Self {
+		Self {
+			frame_ptr: 0,
+			event_id: 0,
+			pending: Arc::new(AtomicBool::new(false)),
+			alive: Arc::new(AtomicBool::new(false)),
+		}
+	}
 	pub(crate) fn new(frame: Frame, alive: Arc<AtomicBool>) -> Self {
-		Self { frame_ptr: frame.handle_ptr() as usize, pending: Arc::new(AtomicBool::new(false)), alive }
+		Self::with_event(frame, alive, ID_UI_WAKE)
+	}
+
+	pub(crate) fn with_event(frame: Frame, alive: Arc<AtomicBool>, event_id: i32) -> Self {
+		Self { frame_ptr: frame.handle_ptr() as usize, event_id, pending: Arc::new(AtomicBool::new(false)), alive }
 	}
 
 	pub(crate) fn wake(&self) {
@@ -29,7 +43,7 @@ impl UiWaker {
 			if handle.is_null() {
 				return;
 			}
-			unsafe { ffi::wxd_Window_PostMenuCommand(handle, ID_UI_WAKE) };
+			unsafe { ffi::wxd_Window_PostMenuCommand(handle, self.event_id) };
 		}
 	}
 


### PR DESCRIPTION
- Start typing a username then hit ALT+A or click the Autocomplete button.
- Any text that was entered goes into the filter box and focus lands in the user list
- If no text was entered, focus lands in the filter box, but TAB reaches all controls in the dialog.
- A filter with nothing in it shows all users in the cache, i.e. users the acount has interacted with- Selecting a valid match and hitting Ok or ENTER replaces the mention with that username and moves the cursor to the end of it.
Assisted by gpt-6-astra, tested by human. Deleting cache rebuilds it on startup, mentioning works with the mnemonic or by using the button. Moved accounts are not eligible for inclusion in the cache, but multiple active accounts from the same user across different instances are.