### PR TITLE
Fix commands sometimes acting on the wrong post.

### DIFF
--- a/src/responses.rs
+++ b/src/responses.rs
@@ -126,9 +126,11 @@ pub fn process_stream_events(
 						&& !status.should_hide(&filter_context)
 						&& status.matches_filter(&timeline_filter, current_user_id)
 					{
-						timeline.entries.insert(0, TimelineEntry::Status(Box::new(*status)));
-						if is_active {
-							active_needs_update = true;
+						if !timeline.entries.iter().any(|entry| entry.id() == status.id) {
+							timeline.entries.insert(0, TimelineEntry::Status(Box::new(*status)));
+							if is_active {
+								active_needs_update = true;
+							}
 						}
 					}
 				}
@@ -175,9 +177,11 @@ pub fn process_stream_events(
 							if notification.kind == "mention" {
 								mention_forwards.push(notification.clone());
 							}
-							timeline.entries.insert(0, TimelineEntry::Notification(Box::new(*notification)));
-							if is_active {
-								active_needs_update = true;
+							if !timeline.entries.iter().any(|entry| entry.id() == notification.id) {
+								timeline.entries.insert(0, TimelineEntry::Notification(Box::new(*notification)));
+								if is_active {
+									active_needs_update = true;
+								}
 							}
 						}
 					}


### PR DESCRIPTION
When rendering, the list silently removes duplicate node ids (TimelineList::update_entries deduplicates by id):
https://github.com/trypsynth/fedra/blob/9845563eb6f85b83a75b13969ba7b6f84da64f07/src/ui/timeline_list.rs#L332
Previously, the underlying Timeline.entries vector retained them. This was because streaming updates inserted statuses/notifications at index 0 without checking whether that id was already present:
https://github.com/trypsynth/fedra/blob/9845563eb6f85b83a75b13969ba7b6f84da64f07/src/responses.rs#L129
https://github.com/trypsynth/fedra/blob/9845563eb6f85b83a75b13969ba7b6f84da64f07/src/responses.rs#L178
That could result in UI list indexes and timeline model indexes being out of sync, which meant that commands would act on the wrong post. Now, streaming updates avoid insertion if the id is already present, ensuring the indexes are synchronised between the model and the UI.