### PR TITLE
Fix Copy Post staying disabled on single-post threads

### DIFF
--- a/src/responses/timelines.rs
+++ b/src/responses/timelines.rs
@@ -9,6 +9,7 @@ use crate::{
 	timeline::{TimelineEntry, TimelineType},
 	ui::{
 		dialogs,
+		menu::update_menu_labels,
 		timeline_view::{sync_timeline_selection_from_list, update_active_timeline_ui},
 	},
 };
@@ -165,6 +166,9 @@ pub(super) fn loaded(
 		status_snapshots
 	};
 	merge_snapshots(ctx, &status_snapshots);
+	if let Some(mb) = ctx.frame.get_menu_bar() {
+		update_menu_labels(&mb, ctx.state);
+	}
 	if should_find_next {
 		ctx.dispatch(UiCommand::FindNext);
 	}
@@ -286,6 +290,9 @@ pub(super) fn search_loaded(
 		status_snapshots
 	};
 	merge_snapshots(ctx, &status_snapshots);
+	if let Some(mb) = ctx.frame.get_menu_bar() {
+		update_menu_labels(&mb, ctx.state);
+	}
 }
 
 pub(super) fn search_failed(


### PR DESCRIPTION
Copy Post (and other post-context menu items) only became enabled reactively, when the timeline list's `on_selection_changed` callback fired from an arrow-key press that actually moved the selection index.

A thread with a single post has nowhere to arrow to, so that callback never fired and Copy Post (Ctrl+Shift+C) stayed disabled after opening such a thread.

## Fix

Call `update_menu_labels` right after entries load in `loaded()` and `search_loaded()` in `src/responses/timelines.rs`, so menu state reflects the current selection as soon as data arrives instead of depending on a later selection change.

Closes #110