### PR TITLE
Fix quote content and thread loading for nested quote chains

### DIFF
--- a/src/mastodon/status.rs
+++ b/src/mastodon/status.rs
@@ -349,16 +349,13 @@ impl Status {
 			self.quote.as_ref().and_then(|q| q.quoted_status.as_ref()).map_or_else(
 				|| (String::new(), String::new(), String::new(), String::new(), String::new()),
 				|quote| {
-					if content.starts_with("RE: http") {
-						if let Some(url_end) = content.find('\n') {
-							content = content[url_end..].trim().to_string();
-						} else if content.split_whitespace().count() <= 2 {
-							content.clear();
-						}
-					}
+					strip_re_prefix(&mut content);
 					let author = quote.account.timeline_display_name(options.display_name_emoji_mode);
 					let username = format!("@{}", quote.account.acct);
-					let content = quote.content_with_cw(options.cw_display, cw_expanded);
+					let mut content = quote.content_with_cw(options.cw_display, cw_expanded);
+					// The quoted post can itself be a quote of another post, in which case its
+					// content carries the same plain-text "RE: <link>" fallback that ours does.
+					strip_re_prefix(&mut content);
 					let media = quote
 						.media_summary(options.cw_display, cw_expanded)
 						.map(|s| format!(" {s}"))
@@ -512,6 +509,18 @@ impl Status {
 		}
 		summary.push(']');
 		Some(summary)
+	}
+}
+
+/// Strips the plain-text "RE: <link>" fallback that quote posts carry in their content for
+/// clients that don't understand structured quotes, leaving just the post's own text.
+fn strip_re_prefix(content: &mut String) {
+	if content.starts_with("RE: http") {
+		if let Some(url_end) = content.find('\n') {
+			*content = content[url_end..].trim().to_string();
+		} else if content.split_whitespace().count() <= 2 {
+			content.clear();
+		}
 	}
 }
 

--- a/src/ui/commands/timeline.rs
+++ b/src/ui/commands/timeline.rs
@@ -656,7 +656,7 @@ pub(super) fn view_quoted_thread(ctx: &mut UiCommandContext<'_>) {
 			{
 				let name = format!("Thread: {}", quoted_status.account.display_name_or_username());
 				let timeline_type = TimelineType::Thread { id: quoted_status.id.clone(), name };
-				Some((timeline_type, *quoted_status.clone()))
+				Some((timeline_type, quoted_status.id.clone()))
 			} else {
 				live_region.announce("No quoted post");
 				None
@@ -664,14 +664,18 @@ pub(super) fn view_quoted_thread(ctx: &mut UiCommandContext<'_>) {
 		},
 	);
 
-	if let Some((timeline_type, focus_status)) = quoted_info {
-		state.pending_restore_post_id = Some((timeline_type.clone(), focus_status.id.clone()));
+	if let Some((timeline_type, status_id)) = quoted_info {
+		state.pending_restore_post_id = Some((timeline_type.clone(), status_id.clone()));
 		open_timeline(state, timelines_selector, timeline_list, &timeline_type, suppress_selection, live_region, frame);
 		let Some(handle) = &state.network_handle else {
 			live_region.announce("Network not available");
 			return;
 		};
-		handle.send(NetworkCommand::FetchThread { timeline_type, focus: Box::new(focus_status) });
+		// The embedded quoted_status is a shallow copy from the quoting post's JSON and may not
+		// carry its own nested quote data, so fetch the full status fresh by id instead of
+		// reusing it as the thread focus (otherwise the quote inside it looked broken until the
+		// thread was manually refreshed).
+		handle.send(NetworkCommand::FetchThreadById { timeline_type, status_id });
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes two related issues with how quoted posts read out when a quote chain is involved (post A quotes post B, and B is itself a quote of post C):

1. Nested quote content showed the raw `RE: <link>` fallback text. Quote posts carry a plain-text `RE: <link>` line in their content as a fallback for clients that don't support structured quotes. That prefix was only stripped from the top-level post's own content, not from the quoted post's content, so a quoted post that was itself a quote read out `RE: <link>` instead of its actual text. The stripping logic is now shared (`strip_re_prefix`) and applied to both.

2. Opening a quoted thread needed a manual refresh to show the nested quote correctly. Opening the thread of a quoted post reused the `quoted_status` embedded in the quoting post's JSON as the thread's focus. That embedded copy is a shallow snapshot and doesn't reliably carry its own nested quote data, so the inner quote looked broken until the thread was manually refreshed (refresh re-fetches the focus status fresh). Opening a quoted thread now fetches the full status by id up front instead of reusing the embedded copy.