### PR TITLE
Preserve scroll position when refreshing a timeline

### DIFF
--- a/src/responses/timelines.rs
+++ b/src/responses/timelines.rs
@@ -112,6 +112,7 @@ pub(super) fn loaded(
 				} else {
 					timeline.entries.extend(filtered.clone());
 				}
+				timeline.next_max_id = next_max_id;
 
 				if is_active {
 					if let Some(idx) = timeline_index_opt {
@@ -126,7 +127,24 @@ pub(super) fn loaded(
 					}
 				}
 			} else {
-				timeline.entries = new_entries;
+				// A fresh fetch of the newest posts (initial open, or a manual/background
+				// refresh). If the timeline already has entries loaded, merge instead of
+				// replacing outright, so posts the user has already scrolled past (and their
+				// selection/scroll position) survive a refresh instead of being wiped by a
+				// full page of just-fetched newest posts.
+				let was_initial_load = timeline.entries.is_empty();
+				if was_initial_load {
+					timeline.entries = new_entries;
+				} else {
+					let existing_ids: std::collections::HashSet<&str> =
+						timeline.entries.iter().map(crate::timeline::TimelineEntry::id).collect();
+					let mut fresh: Vec<TimelineEntry> =
+						new_entries.into_iter().filter(|entry| !existing_ids.contains(entry.id())).collect();
+					if !fresh.is_empty() {
+						fresh.extend(std::mem::take(&mut timeline.entries));
+						timeline.entries = fresh;
+					}
+				}
 				// Restore selected post if it exists in the freshly loaded entries.
 				if let Some(ref id) = restore_id {
 					if timeline.entries.iter().any(|e| e.id() == id.as_str()) {
@@ -145,8 +163,13 @@ pub(super) fn loaded(
 						);
 					}
 				}
+				// Only adopt the new pagination cursor on the initial load; a merge keeps
+				// the existing (older) cursor, which still correctly points past the
+				// combined list's oldest entry for "load more".
+				if was_initial_load {
+					timeline.next_max_id = next_max_id;
+				}
 			}
-			timeline.next_max_id = next_max_id;
 			timeline.loading_more = false;
 			timeline.loading_more_in_background = false;
 			if is_active && timeline.pending_find_next {


### PR DESCRIPTION
## Problem

Refreshing a timeline (manual refresh, or the automatic polling of non-streaming timelines) fetches the newest posts with `max_id: None`. The response handler treated this as a full replace of the timeline's entries, wiping out everything already loaded — including posts reached via "load more". Since selection is tracked by post ID, once the currently selected/read post fell outside that fresh batch of ~40 newest posts, the selection silently reset to the top of the timeline.

## Fix

For a `max_id: None` fetch, merge the freshly fetched posts into the existing entries instead of replacing them outright, when the timeline already has entries loaded (the very first load of a timeline still replaces, since there's nothing yet to merge with). New posts not already present are prepended to the front; existing entries — and the current selection — are left intact. The pagination cursor used for "load more" is left untouched on a merge, since it still correctly points past the combined list's oldest entry.