### PR TITLE
Honor the fetch limit setting on initial timeline loads and refreshes

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -222,12 +222,17 @@ pub fn switch_to_account(
 							handle.send(NetworkCommand::FetchThreadById { timeline_type: t, status_id: id });
 						}
 						TimelineType::Search { query, search_type } => {
-							handle.send(NetworkCommand::Search { query, search_type, limit: Some(40), offset: None });
+							handle.send(NetworkCommand::Search {
+								query,
+								search_type,
+								limit: Some(u32::from(state.config.fetch_limit)),
+								offset: None,
+							});
 						}
 						_ => {
 							handle.send(NetworkCommand::FetchTimeline {
 								timeline_type: t,
-								limit: Some(40),
+								limit: Some(u32::from(state.config.fetch_limit)),
 								max_id: None,
 							});
 						}
@@ -259,7 +264,11 @@ pub fn switch_to_account(
 				if state.timeline_manager.open(t.clone())
 					&& let Some(handle) = &state.network_handle
 				{
-					handle.send(NetworkCommand::FetchTimeline { timeline_type: t, limit: Some(40), max_id: None });
+					handle.send(NetworkCommand::FetchTimeline {
+						timeline_type: t,
+						limit: Some(u32::from(state.config.fetch_limit)),
+						max_id: None,
+					});
 				}
 			}
 		}

--- a/src/responses/helpers.rs
+++ b/src/responses/helpers.rs
@@ -30,7 +30,11 @@ pub(super) fn refresh_own_user_timelines(state: &AppState) {
 		if let crate::timeline::TimelineType::User { ref id, .. } = tt
 			&& id == current_user_id
 		{
-			handle.send(NetworkCommand::FetchTimeline { timeline_type: tt, limit: Some(40), max_id: None });
+			handle.send(NetworkCommand::FetchTimeline {
+				timeline_type: tt,
+				limit: Some(u32::from(state.config.fetch_limit)),
+				max_id: None,
+			});
 		}
 	}
 }

--- a/src/ui/commands/timeline.rs
+++ b/src/ui/commands/timeline.rs
@@ -36,7 +36,11 @@ pub(super) fn refresh_timeline(state: &AppState, live_region: &crate::ui::timeli
 	};
 	match &state.network_handle {
 		Some(handle) => {
-			handle.send(NetworkCommand::FetchTimeline { timeline_type, limit: Some(40), max_id: None });
+			handle.send(NetworkCommand::FetchTimeline {
+				timeline_type,
+				limit: Some(u32::from(state.config.fetch_limit)),
+				max_id: None,
+			});
 		}
 		None => {
 			live_region.announce("Network not available");
@@ -50,7 +54,7 @@ pub(super) fn poll_non_streaming_timelines(state: &AppState) {
 		if timeline.stream_handle.is_none() && timeline.timeline_type.stream_params().is_some() {
 			handle.send(NetworkCommand::FetchTimeline {
 				timeline_type: timeline.timeline_type.clone(),
-				limit: Some(40),
+				limit: Some(u32::from(state.config.fetch_limit)),
 				max_id: None,
 			});
 		}
@@ -112,7 +116,7 @@ pub(super) fn open_timeline(
 		if let Some(handle) = &state.network_handle {
 			handle.send(NetworkCommand::FetchTimeline {
 				timeline_type: timeline_type.clone(),
-				limit: Some(40),
+				limit: Some(u32::from(state.config.fetch_limit)),
 				max_id: None,
 			});
 		}
@@ -556,7 +560,11 @@ pub(super) fn view_thread(ctx: &mut UiCommandContext<'_>) {
 				frame,
 			);
 			if let Some(handle) = &state.network_handle {
-				handle.send(NetworkCommand::FetchTimeline { timeline_type, limit: Some(40), max_id: None });
+				handle.send(NetworkCommand::FetchTimeline {
+					timeline_type,
+					limit: Some(u32::from(state.config.fetch_limit)),
+					max_id: None,
+				});
 			}
 		}
 		TimelineEntry::Notification(notification) if notification.kind == "follow_request" => {
@@ -690,7 +698,12 @@ pub(super) fn search(ctx: &mut UiCommandContext<'_>) {
 		let timeline_type = TimelineType::Search { query: query.clone(), search_type };
 		open_timeline(state, timelines_selector, timeline_list, &timeline_type, suppress_selection, live_region, frame);
 		if let Some(handle) = &state.network_handle {
-			handle.send(NetworkCommand::Search { query, search_type, limit: Some(40), offset: None });
+			handle.send(NetworkCommand::Search {
+				query,
+				search_type,
+				limit: Some(u32::from(state.config.fetch_limit)),
+				offset: None,
+			});
 		}
 	}
 }

--- a/src/ui/dialogs/options.rs
+++ b/src/ui/dialogs/options.rs
@@ -319,7 +319,7 @@ pub fn prompt_for_options(frame: &Frame, input: OptionsDialogInput) -> Option<Op
 	autoload_sizer.add(&autoload_label, 0, SizerFlag::AlignCenterVertical | SizerFlag::Right, 8);
 	autoload_sizer.add(&autoload_choice, 1, SizerFlag::Expand, 0);
 	let fetch_limit_label =
-		StaticText::builder(&timeline_panel).with_label("Posts to &fetch when loading more:").build();
+		StaticText::builder(&timeline_panel).with_label("Posts to &fetch per request:").build();
 	let fetch_limit_spin =
 		SpinCtrl::builder(&timeline_panel).with_range(1, 40).with_initial_value(i32::from(fetch_limit)).build();
 	let fetch_limit_sizer = BoxSizer::builder(Orientation::Horizontal).build();


### PR DESCRIPTION
## Summary

The "Posts to fetch" option (`fetch_limit`) was only applied to the "load more" pagination path. Initial timeline opens, session restore of saved/default timelines, manual refreshes, the own-user pin-state refresh, and search all hardcoded a limit of 40 regardless of what the user configured.

This routes all of those fetches through `config.fetch_limit` as well, and rewords the options dialog label ("Posts to fetch per request:") since the setting now governs every fetch, not just "load more".