### PR TITLE
Fix updater asset suffix mismatch with release artifact names

### DIFF
--- a/src/ui/update_check.rs
+++ b/src/ui/update_check.rs
@@ -12,13 +12,16 @@ pub fn run_update_check(frame: Frame, silent: bool) {
 		crate::config::UpdateChannel::Stable => ShipChannel::Stable,
 		crate::config::UpdateChannel::Dev => ShipChannel::Dev,
 	};
-	let updater_config = Arc::new(UpdaterConfig::new(
-		FEDRA_GITHUB_REPO,
-		"fedra",
-		"Fedra",
-		FEDRA_MINISIGN_KEY,
-		format!("fedra/{}", env!("CARGO_PKG_VERSION")),
-	));
+	let updater_config = Arc::new(
+		UpdaterConfig::new(
+			FEDRA_GITHUB_REPO,
+			"fedra",
+			"Fedra",
+			FEDRA_MINISIGN_KEY,
+			format!("fedra/{}", env!("CARGO_PKG_VERSION")),
+		)
+		.with_asset_suffix(if cfg!(target_arch = "aarch64") { "-arm64" } else { "-x64" }),
+	);
 	ship_shape::ui::run_update_check(
 		updater_config,
 		frame.handle_ptr() as usize,


### PR DESCRIPTION
Fix the auto-updater failing with an "asset error" when a new release is available.

`ship-shape`'s `UpdaterConfig` defaulted to an empty `asset_suffix`, so the updater looked for unsuffixed release assets (`fedra.zip`, `fedra_setup.exe`). `release.yml` always publishes arch-suffixed assets (`fedra-x64.zip`, `fedra_setup-arm64.exe`, etc.), so the updater could never find a matching download/signature pair and failed every time an update was available.

## Fix

Set `asset_suffix` on the `UpdaterConfig` in `src/ui/update_check.rs` based on `target_arch` (`-x64` / `-arm64`) so it matches the names `release.yml` actually uploads.